### PR TITLE
StateT MonadTrans instance and generics reorder

### DIFF
--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/statet.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/statet.kt
@@ -31,19 +31,19 @@ import kotlin.coroutines.CoroutineContext
 
 @extension
 @undocumented
-interface StateTBracket<F, S> : Bracket<StateTPartialOf<F, S>, Throwable>, StateTMonadThrow<F, S> {
+interface StateTBracket<S, F> : Bracket<StateTPartialOf<S, F>, Throwable>, StateTMonadThrow<S, F> {
 
   fun MD(): MonadDefer<F>
 
   override fun ME(): MonadError<F, Throwable> = MD()
 
-  override fun <A, B> StateTOf<F, S, A>.bracketCase(
-    release: (A, ExitCase<Throwable>) -> StateTOf<F, S, Unit>,
-    use: (A) -> StateTOf<F, S, B>
-  ): StateT<F, S, B> = MD().run {
+  override fun <A, B> StateTOf<S, F, A>.bracketCase(
+    release: (A, ExitCase<Throwable>) -> StateTOf<S, F, Unit>,
+    use: (A) -> StateTOf<S, F, B>
+  ): StateT<S, F, B> = MD().run {
 
-    StateT.liftF<F, S, Ref<F, Option<S>>>(this, Ref(this, None)).flatMap { ref ->
-      StateT<F, S, B> { startS ->
+    StateT.liftF<S, F, Ref<F, Option<S>>>(this, Ref(this, None)).flatMap { ref ->
+      StateT<S, F, B> { startS ->
         run(startS).bracketCase(use = { (s, a) ->
           use(a).run(s).flatMap { sa ->
             ref.set(Some(sa.a)).map { sa }
@@ -66,44 +66,44 @@ interface StateTBracket<F, S> : Bracket<StateTPartialOf<F, S>, Throwable>, State
 
 @extension
 @undocumented
-interface StateTMonadDefer<F, S> : MonadDefer<StateTPartialOf<F, S>>, StateTBracket<F, S> {
+interface StateTMonadDefer<S, F> : MonadDefer<StateTPartialOf<S, F>>, StateTBracket<S, F> {
 
   override fun MD(): MonadDefer<F>
 
-  override fun <A> defer(fa: () -> StateTOf<F, S, A>): StateT<F, S, A> = MD().run {
+  override fun <A> defer(fa: () -> StateTOf<S, F, A>): StateT<S, F, A> = MD().run {
     StateT { s -> defer { fa().run(s) } }
   }
 }
 
 @extension
 @undocumented
-interface StateTAsyncInstane<F, S> : Async<StateTPartialOf<F, S>>, StateTMonadDefer<F, S> {
+interface StateTAsyncInstane<S, F> : Async<StateTPartialOf<S, F>>, StateTMonadDefer<S, F> {
 
   fun AS(): Async<F>
 
   override fun MD(): MonadDefer<F> = AS()
 
-  override fun <A> async(fa: Proc<A>): StateT<F, S, A> = AS().run {
+  override fun <A> async(fa: Proc<A>): StateT<S, F, A> = AS().run {
     StateT.liftF(this, async(fa))
   }
 
-  override fun <A> asyncF(k: ProcF<StateTPartialOf<F, S>, A>): StateT<F, S, A> = AS().run {
+  override fun <A> asyncF(k: ProcF<StateTPartialOf<S, F>, A>): StateT<S, F, A> = AS().run {
     StateT { s ->
       asyncF<A> { cb -> k(cb).fix().runA(this, s) }
         .map { Tuple2(s, it) }
     }
   }
 
-  override fun <A> StateTOf<F, S, A>.continueOn(ctx: CoroutineContext): StateT<F, S, A> = AS().run {
+  override fun <A> StateTOf<S, F, A>.continueOn(ctx: CoroutineContext): StateT<S, F, A> = AS().run {
     StateT(AndThen(fix().runF).andThen { it.continueOn(ctx) })
   }
 }
 
 @extension
-interface StateTMonadIO<F, S> : MonadIO<StateTPartialOf<F, S>>, StateTMonad<F, S> {
+interface StateTMonadIO<S, F> : MonadIO<StateTPartialOf<S, F>>, StateTMonad<S, F> {
   fun FIO(): MonadIO<F>
   override fun MF(): Monad<F> = FIO()
-  override fun <A> IO<A>.liftIO(): Kind<StateTPartialOf<F, S>, A> = FIO().run {
+  override fun <A> IO<A>.liftIO(): Kind<StateTPartialOf<S, F>, A> = FIO().run {
     StateT.liftF(this, liftIO())
   }
 }

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/AccumT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/AccumT.kt
@@ -144,7 +144,7 @@ data class AccumT<S, F, A>(val accumT: AccumTFun<S, F, A>) : AccumTOf<S, F, A> {
   /**
    * Convert an accumulation (append-only) computation into a fully stateful computation.
    */
-  fun toStateT(MF: Monad<F>, MS: Monoid<S>): StateT<F, S, A> =
+  fun toStateT(MF: Monad<F>, MS: Monoid<S>): StateT<S, F, A> =
     StateT(
       AndThen.id<S>().flatMap { s: S ->
         AndThen(accumT).andThen {

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
@@ -18,7 +18,7 @@ import arrow.typeclasses.internal.IdBimonad
 /**
  * Alias that represents stateful computation of the form `(S) -> Tuple2<S, A>`.
  */
-typealias StateFun<S, A> = StateTFun<ForId, S, A>
+typealias StateFun<S, A> = StateTFun<S, ForId, A>
 
 /**
  * Alias for StateHK
@@ -28,12 +28,12 @@ typealias ForState = ForStateT
 /**
  * Alias for StateKind
  */
-typealias StateOf<S, A> = StateTOf<ForId, S, A>
+typealias StateOf<S, A> = StateTOf<S, ForId, A>
 
 /**
  * Alias to partially apply type parameters [S] to [State]
  */
-typealias StatePartialOf<S> = StateTPartialOf<ForId, S>
+typealias StatePartialOf<S> = StateTPartialOf<S, ForId>
 
 /**
  * `State<S, A>` is a stateful computation that yields a value of type `A`.
@@ -41,20 +41,20 @@ typealias StatePartialOf<S> = StateTPartialOf<ForId, S>
  * @param S the state we are performing computation upon.
  * @param A current value of computation.
  */
-typealias State<S, A> = StateT<ForId, S, A>
+typealias State<S, A> = StateT<S, ForId, A>
 
 fun <S, A> State<S, A>.run(initial: S): Tuple2<S, A> = runF(initial).extract()
 
 /**
  * Constructor for State.
- * State<S, A> is an alias for IndexedStateT<ForId, S, S, A>
+ * State<S, A> is an alias for IndexedStateT<S, ForId, S, A>
  *
  * @param run the stateful function to wrap with [State].
  */
 fun <S, A> State(run: (S) -> Tuple2<S, A>): State<S, A> = StateT(AndThen(run).andThen { Id(it) })
 
 /**
- * Syntax for constructing a `StateT<ForId, S, A>` from a function `(S) -> Tuple2<S, A>`
+ * Syntax for constructing a `StateT<S, ForId, A>` from a function `(S) -> Tuple2<S, A>`
  */
 fun <S, A> StateFun<S, A>.toState(): State<S, A> = State(this)
 
@@ -70,21 +70,21 @@ fun <S, A, B> State<S, A>.flatMap(f: (A) -> State<S, B>): State<S, B> =
   ))
 
 /**
- * Alias for [StateT.runA] `StateT<ForId, S, A>`
+ * Alias for [StateT.runA] `StateT<S, ForId, A>`
  *
  * @param initial state to start stateful computation.
  */
-fun <S, A> StateT<ForId, S, A>.runA(initial: S): A = run(initial).b
+fun <S, A> StateT<S, ForId, A>.runA(initial: S): A = run(initial).b
 
 /**
- * Alias for [StateT.runS] `StateT<ForId, S, A>`
+ * Alias for [StateT.runS] `StateT<S, ForId, A>`
  *
  * @param initial state to start stateful computation.
  */
-fun <S, A> StateT<ForId, S, A>.runS(initial: S): S = run(initial).a
+fun <S, A> StateT<S, ForId, A>.runS(initial: S): S = run(initial).a
 
 /**
- * Alias for StateId to make working with `StateT<ForId, S, A>` more elegant.
+ * Alias for StateId to make working with `StateT<S, ForId, A>` more elegant.
  */
 fun State() = StateApi
 

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
@@ -47,7 +47,6 @@ fun <S, A> State<S, A>.run(initial: S): Tuple2<S, A> = runF(initial).extract()
 
 /**
  * Constructor for State.
- * State<S, A> is an alias for IndexedStateT<S, ForId, S, A>
  *
  * @param run the stateful function to wrap with [State].
  */

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
@@ -25,7 +25,7 @@ fun <S, F, A> StateTOf<S, F, A>.run(initial: S): Kind<F, Tuple2<S, A>> = fix().r
 
 /**
  * `StateT<S, F, A>` is a stateful computation within a context `F` yielding
- * a value of type `A`. i.e. StateT<EitherPartialOf<E>, S, A> = Either<E, State<S, A>>
+ * a value of type `A`. i.e. StateT<S, EitherPartialOf<E>, A> = Either<E, State<S, A>>
  *
  * @param F the context that wraps the stateful computation.
  * @param S the state we are performing computation upon.
@@ -65,8 +65,6 @@ class StateT<S, F, A> private constructor(
     /**
      * Inspect a value of the state [S] with [f] `(S) -> T` without modifying the state.
      *
-     *
-     *
      * @param AF [Applicative] for the context [F].
      * @param f the function applied to inspect [T] from [S].
      */
@@ -87,7 +85,7 @@ class StateT<S, F, A> private constructor(
       }
 
     /**
-     * Modify the state with an [Applicative] function [f] `(S) -> Kind<S, F>` and return [Unit].
+     * Modify the state with an [Applicative] function [f] `(S) -> Kind<F, S>` and return [Unit].
      *
      * @param AF [Applicative] for the context [F].
      * @param f the modify function to apply.
@@ -105,7 +103,7 @@ class StateT<S, F, A> private constructor(
       StateT { _ -> AF.just(Tuple2(s, Unit)) }
 
     /**
-     * Set the state to a value [s] of type `Kind<S, F>` and return [Unit].
+     * Set the state to a value [s] of type `Kind<F, S>` and return [Unit].
      *
      * @param AF [Applicative] for the context [F].
      * @param s value to set.

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
@@ -14,17 +14,17 @@ import arrow.typeclasses.SemigroupK
 /**
  * Alias that represent stateful computation of the form `(S) -> Tuple2<S, A>` with a result in certain context `F`.
  */
-typealias StateTFun<F, S, A> = (S) -> Kind<F, Tuple2<S, A>>
+typealias StateTFun<S, F, A> = (S) -> Kind<F, Tuple2<S, A>>
 
 /**
  * Run the stateful computation within the context `F`.
  *
  * @param initial state to start stateful computation
  */
-fun <F, S, A> StateTOf<F, S, A>.run(initial: S): Kind<F, Tuple2<S, A>> = fix().runF(initial)
+fun <S, F, A> StateTOf<S, F, A>.run(initial: S): Kind<F, Tuple2<S, A>> = fix().runF(initial)
 
 /**
- * `StateT<F, S, A>` is a stateful computation within a context `F` yielding
+ * `StateT<S, F, A>` is a stateful computation within a context `F` yielding
  * a value of type `A`. i.e. StateT<EitherPartialOf<E>, S, A> = Either<E, State<S, A>>
  *
  * @param F the context that wraps the stateful computation.
@@ -33,24 +33,24 @@ fun <F, S, A> StateTOf<F, S, A>.run(initial: S): Kind<F, Tuple2<S, A>> = fix().r
  * @param runF the stateful computation that is wrapped and managed by `StateT`
  */
 @higherkind
-class StateT<F, S, A> private constructor(
-  val runF: StateTFun<F, S, A>
-) : StateTOf<F, S, A>, StateTKindedJ<F, S, A> {
+class StateT<S, F, A> private constructor(
+  val runF: StateTFun<S, F, A>
+) : StateTOf<S, F, A>, StateTKindedJ<S, F, A> {
 
   companion object {
 
-    operator fun <F, S, A> invoke(f: (S) -> Kind<F, Tuple2<S, A>>): StateT<F, S, A> = StateT(f)
+    operator fun <S, F, A> invoke(f: (S) -> Kind<F, Tuple2<S, A>>): StateT<S, F, A> = StateT(f)
 
-    fun <F, S, T> just(AF: Applicative<F>, t: T): StateT<F, S, T> =
+    fun <S, F, T> just(AF: Applicative<F>, t: T): StateT<S, F, T> =
       StateT { s -> AF.just(s toT t) }
 
     /**
-     * Lift a value of type `Kind<F, A>` into `StateT<F, S, A>`.
+     * Lift a value of type `Kind<F, A>` into `StateT<S, F, A>`.
      *
      * @param AF [Applicative] for the context [F].
      * @param fa the value to liftF.
      */
-    fun <F, S, A> liftF(AF: Applicative<F>, fa: Kind<F, A>): StateT<F, S, A> = AF.run {
+    fun <S, F, A> liftF(AF: Applicative<F>, fa: Kind<F, A>): StateT<S, F, A> = AF.run {
       StateT { s -> fa.map { a -> Tuple2(s, a) } }
     }
 
@@ -59,7 +59,7 @@ class StateT<F, S, A> private constructor(
      *
      * @param AF [Applicative] for the context [F].
      */
-    fun <F, S> get(AF: Applicative<F>): StateT<F, S, S> =
+    fun <S, F> get(AF: Applicative<F>): StateT<S, F, S> =
       StateT { s -> AF.just(Tuple2(s, s)) }
 
     /**
@@ -70,7 +70,7 @@ class StateT<F, S, A> private constructor(
      * @param AF [Applicative] for the context [F].
      * @param f the function applied to inspect [T] from [S].
      */
-    fun <F, S, T> inspect(AF: Applicative<F>, f: (S) -> T): StateT<F, S, T> =
+    fun <S, F, T> inspect(AF: Applicative<F>, f: (S) -> T): StateT<S, F, T> =
       StateT { s -> AF.just(Tuple2(s, f(s))) }
 
     /**
@@ -79,7 +79,7 @@ class StateT<F, S, A> private constructor(
      * @param AF [Applicative] for the context [F].
      * @param f the modify function to apply.
      */
-    fun <F, S> modify(AF: Applicative<F>, f: (S) -> S): StateT<F, S, Unit> =
+    fun <S, F> modify(AF: Applicative<F>, f: (S) -> S): StateT<S, F, Unit> =
       StateT { s ->
         AF.run {
           just(f(s)).map { Tuple2(it, Unit) }
@@ -87,12 +87,12 @@ class StateT<F, S, A> private constructor(
       }
 
     /**
-     * Modify the state with an [Applicative] function [f] `(S) -> Kind<F, S>` and return [Unit].
+     * Modify the state with an [Applicative] function [f] `(S) -> Kind<S, F>` and return [Unit].
      *
      * @param AF [Applicative] for the context [F].
      * @param f the modify function to apply.
      */
-    fun <F, S> modifyF(AF: Applicative<F>, f: (S) -> Kind<F, S>): StateT<F, S, Unit> =
+    fun <S, F> modifyF(AF: Applicative<F>, f: (S) -> Kind<F, S>): StateT<S, F, Unit> =
       StateT { s -> AF.run { f(s).map { Tuple2(it, Unit) } } }
 
     /**
@@ -101,16 +101,16 @@ class StateT<F, S, A> private constructor(
      * @param AF [Applicative] for the context [F].
      * @param s value to set.
      */
-    fun <F, S> set(AF: Applicative<F>, s: S): StateT<F, S, Unit> =
+    fun <S, F> set(AF: Applicative<F>, s: S): StateT<S, F, Unit> =
       StateT { _ -> AF.just(Tuple2(s, Unit)) }
 
     /**
-     * Set the state to a value [s] of type `Kind<F, S>` and return [Unit].
+     * Set the state to a value [s] of type `Kind<S, F>` and return [Unit].
      *
      * @param AF [Applicative] for the context [F].
      * @param s value to set.
      */
-    fun <F, S> setF(AF: Applicative<F>, s: Kind<F, S>): StateT<F, S, Unit> =
+    fun <S, F> setF(AF: Applicative<F>, s: Kind<F, S>): StateT<S, F, Unit> =
       StateT { _ -> AF.run { s.map { Tuple2(it, Unit) } } }
 
     /**
@@ -120,7 +120,7 @@ class StateT<F, S, A> private constructor(
      * @param a initial value to start running recursive call to [f]
      * @param f function that is called recusively until [arrow.Either.Right] is returned.
      */
-    fun <F, S, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> StateTOf<F, S, Either<A, B>>): StateT<F, S, B> = MF.run {
+    fun <S, F, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> StateTOf<S, F, Either<A, B>>): StateT<S, F, B> = MF.run {
       StateT { s: S ->
         tailRecM(Tuple2(s, a)) { (s, a0) ->
           f(a0).run(s).map { (s, ab) ->
@@ -137,7 +137,7 @@ class StateT<F, S, A> private constructor(
    * @param FF [Functor] for the context [F].
    * @param f the function to apply.
    */
-  fun <B> map(FF: Functor<F>, f: (A) -> B): StateT<F, S, B> = transform(FF) { (s, a) -> Tuple2(s, f(a)) }
+  fun <B> map(FF: Functor<F>, f: (A) -> B): StateT<S, F, B> = transform(FF) { (s, a) -> Tuple2(s, f(a)) }
 
   /**
    * Apply a function `(S) -> B` that operates within the [StateT] context.
@@ -145,7 +145,7 @@ class StateT<F, S, A> private constructor(
    * @param MF [Monad] for the context [F].
    * @param ff function with the [StateT] context.
    */
-  fun <B> ap(MF: Monad<F>, ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
+  fun <B> ap(MF: Monad<F>, ff: StateTOf<S, F, (A) -> B>): StateT<S, F, B> =
     flatMap(MF) { a -> ff.fix().map(MF) { f -> f(a) } }
 
   /**
@@ -154,7 +154,7 @@ class StateT<F, S, A> private constructor(
    * @param MF [Monad] for the context [F].
    * @param fas the function to apply.
    */
-  fun <B> flatMap(MF: Monad<F>, fas: (A) -> StateTOf<F, S, B>): StateT<F, S, B> =
+  fun <B> flatMap(MF: Monad<F>, fas: (A) -> StateTOf<S, F, B>): StateT<S, F, B> =
     StateT(AndThen(runF).andThen { fsa ->
       MF.run {
         fsa.flatMap {
@@ -169,7 +169,7 @@ class StateT<F, S, A> private constructor(
    * @param MF [Monad] for the context [F].
    * @param faf the function to apply.
    */
-  fun <B> flatMapF(MF: Monad<F>, faf: (A) -> Kind<F, B>): StateT<F, S, B> =
+  fun <B> flatMapF(MF: Monad<F>, faf: (A) -> Kind<F, B>): StateT<S, F, B> =
     StateT(AndThen(runF).andThen { fsa ->
       MF.run {
         fsa.flatMap { (s, a) ->
@@ -184,7 +184,7 @@ class StateT<F, S, A> private constructor(
    * @param FF [Functor] for the context [F].
    * @param f the function to apply.
    */
-  fun <B> transform(FF: Functor<F>, f: (Tuple2<S, A>) -> Tuple2<S, B>): StateT<F, S, B> =
+  fun <B> transform(FF: Functor<F>, f: (Tuple2<S, A>) -> Tuple2<S, B>): StateT<S, F, B> =
     StateT(AndThen(runF).andThen { fsa ->
       FF.run {
         fsa.map(f)
@@ -197,7 +197,7 @@ class StateT<F, S, A> private constructor(
    * @param SF [SemigroupK] for [F].
    * @param y other [StateT] object to combine.
    */
-  fun combineK(SF: SemigroupK<F>, y: StateTOf<F, S, A>): StateT<F, S, A> =
+  fun combineK(SF: SemigroupK<F>, y: StateTOf<S, F, A>): StateT<S, F, A> =
     StateT(AndThen(runF).flatMap { fa ->
       AndThen(y.fix().runF).andThen { fb ->
         SF.run {
@@ -230,4 +230,4 @@ class StateT<F, S, A> private constructor(
 /**
  * Wrap the function with [StateT].
  */
-fun <F, S, A> StateTFun<F, S, A>.stateT(): StateT<F, S, A> = StateT(this)
+fun <S, F, A> StateTFun<S, F, A>.stateT(): StateT<S, F, A> = StateT(this)

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/AccumTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/AccumTTest.kt
@@ -84,9 +84,9 @@ class AccumTTest : UnitSpec() {
       ),
 
       MonadStateLaws.laws(
-        AccumT.monadState<Int, Int, StateTPartialOf<ForId, Int>>(StateT.monadState(Id.monad()), Int.monoid()),
+        AccumT.monadState<Int, Int, StateTPartialOf<Int, ForId>>(StateT.monadState(Id.monad()), Int.monoid()),
         AccumT.genK(StateT.genK(Id.genK(), Gen.int()), Gen.int()),
-        AccumT.eqK<Int, StateTPartialOf<ForId, Int>>(
+        AccumT.eqK<Int, StateTPartialOf<Int, ForId>>(
           StateT.monad(Id.monad()),
           StateT.eqK(Id.eqK(), Int.eq(), Id.monad(), 1),
           Int.eq(),

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
@@ -43,54 +43,54 @@ import arrow.undocumented
 
 @extension
 @undocumented
-interface StateTFunctor<F, S> : Functor<StateTPartialOf<F, S>> {
+interface StateTFunctor<S, F> : Functor<StateTPartialOf<S, F>> {
 
   fun FF(): Functor<F>
 
-  override fun <A, B> StateTOf<F, S, A>.map(f: (A) -> B): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.map(f: (A) -> B): StateT<S, F, B> =
     fix().map(FF(), f)
 }
 
 @extension
 @undocumented
-interface StateTApplicative<F, S> : Applicative<StateTPartialOf<F, S>>, StateTFunctor<F, S> {
+interface StateTApplicative<S, F> : Applicative<StateTPartialOf<S, F>>, StateTFunctor<S, F> {
 
   fun MF(): Monad<F>
 
   override fun FF(): Functor<F> = MF()
 
-  override fun <A, B> StateTOf<F, S, A>.map(f: (A) -> B): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.map(f: (A) -> B): StateT<S, F, B> =
     fix().map(MF(), f)
 
-  override fun <A> just(a: A): StateT<F, S, A> =
+  override fun <A> just(a: A): StateT<S, F, A> =
     StateT.just(MF(), a)
 
-  override fun <A, B> StateTOf<F, S, A>.ap(ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.ap(ff: StateTOf<S, F, (A) -> B>): StateT<S, F, B> =
     fix().ap(MF(), ff)
 
-  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.lazyAp(ff: () -> Kind<StateTPartialOf<F, S>, (A) -> B>): Kind<StateTPartialOf<F, S>, B> =
+  override fun <A, B> Kind<StateTPartialOf<S, F>, A>.lazyAp(ff: () -> Kind<StateTPartialOf<S, F>, (A) -> B>): Kind<StateTPartialOf<S, F>, B> =
     flatMap(MF()) { a -> ff().map { f -> f(a) } }
 }
 
 @extension
 @undocumented
-interface StateTMonad<F, S> : Monad<StateTPartialOf<F, S>>, StateTApplicative<F, S> {
+interface StateTMonad<S, F> : Monad<StateTPartialOf<S, F>>, StateTApplicative<S, F> {
 
   override fun MF(): Monad<F>
 
-  override fun <A, B> StateTOf<F, S, A>.map(f: (A) -> B): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.map(f: (A) -> B): StateT<S, F, B> =
     fix().map(MF(), f)
 
-  override fun <A, B> StateTOf<F, S, A>.flatMap(f: (A) -> StateTOf<F, S, B>): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.flatMap(f: (A) -> StateTOf<S, F, B>): StateT<S, F, B> =
     fix().flatMap(MF(), f)
 
-  override fun <A, B> tailRecM(a: A, f: (A) -> StateTOf<F, S, Either<A, B>>): StateT<F, S, B> =
+  override fun <A, B> tailRecM(a: A, f: (A) -> StateTOf<S, F, Either<A, B>>): StateT<S, F, B> =
     StateT.tailRecM(MF(), a, f)
 
-  override fun <A, B> StateTOf<F, S, A>.ap(ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
+  override fun <A, B> StateTOf<S, F, A>.ap(ff: StateTOf<S, F, (A) -> B>): StateT<S, F, B> =
     fix().ap(MF(), ff.fix())
 
-  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.lazyAp(ff: () -> Kind<StateTPartialOf<F, S>, (A) -> B>): Kind<StateTPartialOf<F, S>, B> =
+  override fun <A, B> Kind<StateTPartialOf<S, F>, A>.lazyAp(ff: () -> Kind<StateTPartialOf<S, F>, (A) -> B>): Kind<StateTPartialOf<S, F>, B> =
     StateT(AndThen.id<S>().flatMap { s ->
       AndThen(fix().runF).andThen { fa ->
         MF().run {
@@ -102,26 +102,26 @@ interface StateTMonad<F, S> : Monad<StateTPartialOf<F, S>>, StateTApplicative<F,
 
 @extension
 @undocumented
-interface StateTSemigroupK<F, S> : SemigroupK<StateTPartialOf<F, S>> {
+interface StateTSemigroupK<S, F> : SemigroupK<StateTPartialOf<S, F>> {
   fun SS(): SemigroupK<F>
 
-  override fun <A> StateTOf<F, S, A>.combineK(y: StateTOf<F, S, A>): StateT<F, S, A> =
+  override fun <A> StateTOf<S, F, A>.combineK(y: StateTOf<S, F, A>): StateT<S, F, A> =
     fix().combineK(SS(), y)
 }
 
 @extension
 @undocumented
-interface StateTMonoidK<F, S> : MonoidK<StateTPartialOf<F, S>>, StateTSemigroupK<F, S> {
+interface StateTMonoidK<S, F> : MonoidK<StateTPartialOf<S, F>>, StateTSemigroupK<S, F> {
   fun MF(): Monad<F>
   fun MO(): MonoidK<F>
   override fun SS(): SemigroupK<F> = MO()
 
-  override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = StateT.liftF(MF(), MO().empty<A>())
+  override fun <A> empty(): Kind<StateTPartialOf<S, F>, A> = StateT.liftF(MF(), MO().empty<A>())
 }
 
 @extension
 @undocumented
-interface StateTApplicativeError<F, S, E> : ApplicativeError<StateTPartialOf<F, S>, E>, StateTApplicative<F, S> {
+interface StateTApplicativeError<S, F, E> : ApplicativeError<StateTPartialOf<S, F>, E>, StateTApplicative<S, F> {
 
   fun ME(): MonadError<F, E>
 
@@ -129,11 +129,11 @@ interface StateTApplicativeError<F, S, E> : ApplicativeError<StateTPartialOf<F, 
 
   override fun MF(): Monad<F> = ME()
 
-  override fun <A> raiseError(e: E): StateTOf<F, S, A> = ME().run {
+  override fun <A> raiseError(e: E): StateTOf<S, F, A> = ME().run {
     StateT.liftF(this, raiseError(e))
   }
 
-  override fun <A> StateTOf<F, S, A>.handleErrorWith(f: (E) -> StateTOf<F, S, A>): StateT<F, S, A> =
+  override fun <A> StateTOf<S, F, A>.handleErrorWith(f: (E) -> StateTOf<S, F, A>): StateT<S, F, A> =
     StateT(AndThen.id<S>().flatMap { s ->
       AndThen(fix().runF).andThen {
         ME().run {
@@ -145,7 +145,7 @@ interface StateTApplicativeError<F, S, E> : ApplicativeError<StateTPartialOf<F, 
 
 @extension
 @undocumented
-interface StateTMonadError<F, S, E> : MonadError<StateTPartialOf<F, S>, E>, StateTApplicativeError<F, S, E>, StateTMonad<F, S> {
+interface StateTMonadError<S, F, E> : MonadError<StateTPartialOf<S, F>, E>, StateTApplicativeError<S, F, E>, StateTMonad<S, F> {
 
   override fun ME(): MonadError<F, E>
 
@@ -154,28 +154,28 @@ interface StateTMonadError<F, S, E> : MonadError<StateTPartialOf<F, S>, E>, Stat
 
 @extension
 @undocumented
-interface StateTMonadThrow<F, S> : MonadThrow<StateTPartialOf<F, S>>, StateTMonadError<F, S, Throwable> {
+interface StateTMonadThrow<S, F> : MonadThrow<StateTPartialOf<S, F>>, StateTMonadError<S, F, Throwable> {
   override fun ME(): MonadError<F, Throwable>
 }
 
 @extension
 @undocumented
-interface StateTContravariantInstance<F, S> : Contravariant<StateTPartialOf<F, S>> {
+interface StateTContravariantInstance<S, F> : Contravariant<StateTPartialOf<S, F>> {
 
   fun CF(): Contravariant<F>
 
-  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.contramap(f: (B) -> A): Kind<StateTPartialOf<F, S>, B> =
+  override fun <A, B> Kind<StateTPartialOf<S, F>, A>.contramap(f: (B) -> A): Kind<StateTPartialOf<S, F>, B> =
     StateT(AndThen(fix().runF).andThen { fa -> CF().run { fa.contramap { (s, b): Tuple2<S, B> -> s toT f(b) } } })
 }
 
 @extension
 @undocumented
-interface StateTDivideInstance<F, S> : Divide<StateTPartialOf<F, S>>, StateTContravariantInstance<F, S> {
+interface StateTDivideInstance<S, F> : Divide<StateTPartialOf<S, F>>, StateTContravariantInstance<S, F> {
 
   fun DF(): Divide<F>
   override fun CF(): Contravariant<F> = DF()
 
-  override fun <A, B, Z> divide(fa: Kind<StateTPartialOf<F, S>, A>, fb: Kind<StateTPartialOf<F, S>, B>, f: (Z) -> Tuple2<A, B>): Kind<StateTPartialOf<F, S>, Z> =
+  override fun <A, B, Z> divide(fa: Kind<StateTPartialOf<S, F>, A>, fb: Kind<StateTPartialOf<S, F>, B>, f: (Z) -> Tuple2<A, B>): Kind<StateTPartialOf<S, F>, Z> =
     StateT(AndThen(fa.fix().runF).flatMap { fa ->
       AndThen(fb.fix().runF).andThen { fb ->
         DF().divide(fa, fb) { (s, z): Tuple2<S, Z> ->
@@ -188,21 +188,21 @@ interface StateTDivideInstance<F, S> : Divide<StateTPartialOf<F, S>>, StateTCont
 
 @extension
 @undocumented
-interface StateTDivisibleInstance<F, S> : Divisible<StateTPartialOf<F, S>>, StateTDivideInstance<F, S> {
+interface StateTDivisibleInstance<S, F> : Divisible<StateTPartialOf<S, F>>, StateTDivideInstance<S, F> {
   fun DFF(): Divisible<F>
   override fun DF(): Divide<F> = DFF()
 
-  override fun <A> conquer(): Kind<StateTPartialOf<F, S>, A> =
+  override fun <A> conquer(): Kind<StateTPartialOf<S, F>, A> =
     StateT { DFF().conquer() }
 }
 
 @extension
 @undocumented
-interface StateTDecidableInstante<F, S> : Decidable<StateTPartialOf<F, S>>, StateTDivisibleInstance<F, S> {
+interface StateTDecidableInstante<S, F> : Decidable<StateTPartialOf<S, F>>, StateTDivisibleInstance<S, F> {
   fun DFFF(): Decidable<F>
   override fun DFF(): Divisible<F> = DFFF()
 
-  override fun <A, B, Z> choose(fa: Kind<StateTPartialOf<F, S>, A>, fb: Kind<StateTPartialOf<F, S>, B>, f: (Z) -> Either<A, B>): Kind<StateTPartialOf<F, S>, Z> =
+  override fun <A, B, Z> choose(fa: Kind<StateTPartialOf<S, F>, A>, fb: Kind<StateTPartialOf<S, F>, B>, f: (Z) -> Either<A, B>): Kind<StateTPartialOf<S, F>, Z> =
     StateT(AndThen(fa.fix().runF).flatMap { fa ->
       AndThen(fb.fix().runF).andThen { fb ->
         DFFF().choose(fa, fb) { (s, z): Tuple2<S, Z> ->
@@ -219,36 +219,36 @@ interface StateTDecidableInstante<F, S> : Decidable<StateTPartialOf<F, S>>, Stat
 /**
  * Alias for[StateT.Companion.applicative]
  */
-fun <S> StateApi.applicative(): Applicative<StateTPartialOf<ForId, S>> = StateT.applicative(Id.monad())
+fun <S> StateApi.applicative(): Applicative<StateTPartialOf<S, ForId>> = StateT.applicative(Id.monad())
 
 /**
  * Alias for [StateT.Companion.functor]
  */
-fun <S> StateApi.functor(): Functor<StateTPartialOf<ForId, S>> = StateT.functor(Id.monad())
+fun <S> StateApi.functor(): Functor<StateTPartialOf<S, ForId>> = StateT.functor(Id.monad())
 
 /**
  * Alias for [StateT.Companion.monad]
  */
-fun <S> StateApi.monad(): Monad<StateTPartialOf<ForId, S>> = StateT.monad(Id.monad())
+fun <S> StateApi.monad(): Monad<StateTPartialOf<S, ForId>> = StateT.monad(Id.monad())
 
-fun <F, S, A> StateT.Companion.fx(M: Monad<F>, c: suspend MonadSyntax<StateTPartialOf<F, S>>.() -> A): StateT<F, S, A> =
-  StateT.monad<F, S>(M).fx.monad(c).fix()
+fun <S, F, A> StateT.Companion.fx(M: Monad<F>, c: suspend MonadSyntax<StateTPartialOf<S, F>>.() -> A): StateT<S, F, A> =
+  StateT.monad<S, F>(M).fx.monad(c).fix()
 
 fun <S, A> StateApi.fx(c: suspend MonadSyntax<StatePartialOf<S>>.() -> A): State<S, A> =
   StateApi.monad<S>().fx.monad(c).fix()
 
 @extension
-interface StateTMonadState<F, S> : MonadState<StateTPartialOf<F, S>, S>, StateTMonad<F, S> {
+interface StateTMonadState<S, F> : MonadState<StateTPartialOf<S, F>, S>, StateTMonad<S, F> {
 
   override fun MF(): Monad<F>
 
-  override fun get(): StateT<F, S, S> = StateT.get(MF())
+  override fun get(): StateT<S, F, S> = StateT.get(MF())
 
-  override fun set(s: S): StateT<F, S, Unit> = StateT.set(MF(), s)
+  override fun set(s: S): StateT<S, F, Unit> = StateT.set(MF(), s)
 }
 
 @extension
-interface StateTMonadCombine<F, S> : MonadCombine<StateTPartialOf<F, S>>, StateTMonad<F, S>, StateTAlternative<F, S> {
+interface StateTMonadCombine<S, F> : MonadCombine<StateTPartialOf<S, F>>, StateTMonad<S, F>, StateTAlternative<S, F> {
 
   fun MC(): MonadCombine<F>
   override fun AF(): Alternative<F> = MC()
@@ -258,22 +258,22 @@ interface StateTMonadCombine<F, S> : MonadCombine<StateTPartialOf<F, S>>, StateT
   override fun FF(): Monad<F> = MC()
   override fun MO(): MonoidK<F> = MC()
 
-  override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = liftT(MC().empty())
+  override fun <A> empty(): Kind<StateTPartialOf<S, F>, A> = liftT(MC().empty())
 
-  fun <A> liftT(ma: Kind<F, A>): StateT<F, S, A> = FF().run {
+  fun <A> liftT(ma: Kind<F, A>): StateT<S, F, A> = FF().run {
     StateT { s: S -> ma.map { a: A -> s toT a } }
   }
 }
 
 @extension
-interface StateTAlternative<F, S> : Alternative<StateTPartialOf<F, S>>, StateTMonoidK<F, S>, StateTApplicative<F, S> {
+interface StateTAlternative<S, F> : Alternative<StateTPartialOf<S, F>>, StateTMonoidK<S, F>, StateTApplicative<S, F> {
   override fun MF(): Monad<F>
   override fun MO(): MonoidK<F> = AF()
   fun AF(): Alternative<F>
 
-  override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = StateT.liftF(AF(), AF().empty<A>())
+  override fun <A> empty(): Kind<StateTPartialOf<S, F>, A> = StateT.liftF(AF(), AF().empty<A>())
 
-  override fun <A> Kind<StateTPartialOf<F, S>, A>.orElse(b: Kind<StateTPartialOf<F, S>, A>): Kind<StateTPartialOf<F, S>, A> =
+  override fun <A> Kind<StateTPartialOf<S, F>, A>.orElse(b: Kind<StateTPartialOf<S, F>, A>): Kind<StateTPartialOf<S, F>, A> =
     StateT(AndThen(fix().runF).flatMap { fa ->
       AndThen(b.fix().runF).andThen { fb ->
         AF().run { fa.orElse(fb) }
@@ -281,13 +281,13 @@ interface StateTAlternative<F, S> : Alternative<StateTPartialOf<F, S>>, StateTMo
     })
 
   // Note: This can stackoverflow if `F` is not stacksafe, which is a tradeoff for having true short-circuit
-  override fun <A> Kind<StateTPartialOf<F, S>, A>.lazyOrElse(b: () -> Kind<StateTPartialOf<F, S>, A>): Kind<StateTPartialOf<F, S>, A> =
+  override fun <A> Kind<StateTPartialOf<S, F>, A>.lazyOrElse(b: () -> Kind<StateTPartialOf<S, F>, A>): Kind<StateTPartialOf<S, F>, A> =
     StateT(AndThen.id<S>().flatMap { s ->
       AndThen(fix().runF).andThen { fa ->
         AF().run { fa.lazyOrElse { b().fix().run(s) } }
       }
     })
 
-  override fun <A> StateTOf<F, S, A>.combineK(y: StateTOf<F, S, A>): StateT<F, S, A> =
+  override fun <A> StateTOf<S, F, A>.combineK(y: StateTOf<S, F, A>): StateT<S, F, A> =
     orElse(y).fix()
 }

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
@@ -1,6 +1,7 @@
 package arrow.mtl.extensions
 
 import arrow.Kind
+import arrow.Kind2
 import arrow.core.AndThen
 import arrow.core.Either
 import arrow.core.ForId
@@ -11,6 +12,7 @@ import arrow.core.left
 import arrow.core.right
 import arrow.core.toT
 import arrow.extension
+import arrow.mtl.ForStateT
 import arrow.mtl.State
 import arrow.mtl.StateApi
 import arrow.mtl.StatePartialOf
@@ -24,6 +26,7 @@ import arrow.mtl.extensions.statet.monad.monad
 import arrow.mtl.fix
 import arrow.mtl.run
 import arrow.mtl.typeclasses.MonadState
+import arrow.mtl.typeclasses.MonadTrans
 import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
@@ -290,4 +293,10 @@ interface StateTAlternative<S, F> : Alternative<StateTPartialOf<S, F>>, StateTMo
 
   override fun <A> StateTOf<S, F, A>.combineK(y: StateTOf<S, F, A>): StateT<S, F, A> =
     orElse(y).fix()
+}
+
+@extension
+interface StateTMonadTrans<S> : MonadTrans<Kind<ForStateT, S>> {
+  override fun <G, A> Kind<G, A>.liftT(MG: Monad<G>): Kind2<Kind<ForStateT, S>, G, A> =
+    StateT.liftF(MG, this)
 }


### PR DESCRIPTION
Changed `StateT<F, S, A>` -> `StateT<S, F, A>`. 

This has a few benefits, mainly we can now write abstractions over `Kind<ForStateT, S>` where the inner `F` is unknown. Examples of this are `MonadTrans`, but also more complex typeclasses that deal with monad stacks like `MonadBaseControl` are now possible.