### PR TITLE
Kleisli MonadTrans instance and generics reorder

### DIFF
--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/AccumT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/AccumT.kt
@@ -160,7 +160,7 @@ data class AccumT<S, F, A>(val accumT: AccumTFun<S, F, A>) : AccumTOf<S, F, A> {
 /**
  * Convert a read-only computation into an accumulation computation.
  */
-fun <F, S, A> ReaderT<F, S, A>.toAccumT(
+fun <F, S, A> ReaderT<S, F, A>.toAccumT(
   FF: Functor<F>,
   MS: Monoid<S>
 ): AccumT<S, F, A> =

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/Reader.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/Reader.kt
@@ -29,24 +29,24 @@ typealias ForReader = ForReaderT
  *
  * @see ReaderTKind
  */
-typealias ReaderOf<D, A> = ReaderTOf<ForId, D, A>
+typealias ReaderOf<D, A> = ReaderTOf<D, ForId, A>
 
 /**
  * Alias to partially apply type parameter [D] to [Reader].
  *
  * @see ReaderTKindPartial
  */
-typealias ReaderPartialOf<D> = ReaderTPartialOf<ForId, D>
+typealias ReaderPartialOf<D> = ReaderTPartialOf<D, ForId>
 
 /**
  * [Reader] represents a computation that has a dependency on [D].
- * `Reader<D, A>` is an alias for `ReaderT<ForId, D, A>` and `Kleisli<ForId, D, A>`.
+ * `Reader<D, A>` is an alias for `ReaderT<D, ForId, A>` and `Kleisli<D, ForId, A>`.
  *
  * @param D the dependency or environment we depend on.
  * @param A resulting type of the computation.
  * @see ReaderT
  */
-typealias Reader<D, A> = ReaderT<ForId, D, A>
+typealias Reader<D, A> = ReaderT<D, ForId, A>
 
 /**
  * Constructor for [Reader].

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/KleisliTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/KleisliTest.kt
@@ -6,11 +6,8 @@ import arrow.core.ConstPartialOf
 import arrow.core.ForConst
 import arrow.core.ForId
 import arrow.core.ForOption
-import arrow.core.ForTry
 import arrow.core.Id
 import arrow.core.Option
-import arrow.core.Try
-import arrow.core.extensions.`try`.eqK.eqK
 import arrow.core.extensions.const.divisible.divisible
 import arrow.core.extensions.const.eqK.eqK
 import arrow.core.extensions.eq
@@ -28,9 +25,7 @@ import arrow.fx.mtl.concurrent
 import arrow.fx.mtl.timer
 import arrow.mtl.extensions.kleisli.alternative.alternative
 import arrow.mtl.extensions.kleisli.applicative.applicative
-import arrow.mtl.extensions.kleisli.contravariant.contravariant
 import arrow.mtl.extensions.kleisli.divisible.divisible
-import arrow.mtl.extensions.kleisli.eqK.eqK
 import arrow.mtl.extensions.kleisli.functor.functor
 import arrow.mtl.extensions.kleisli.monad.monad
 import arrow.test.UnitSpec
@@ -38,73 +33,63 @@ import arrow.test.generators.GenK
 import arrow.test.generators.genK
 import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.ConcurrentLaws
-import arrow.test.laws.ContravariantLaws
 import arrow.test.laws.DivisibleLaws
-import arrow.typeclasses.Conested
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
-import arrow.typeclasses.conest
-import arrow.typeclasses.counnest
 import io.kotlintest.properties.Gen
 import io.kotlintest.shouldBe
 
 class KleisliTest : UnitSpec() {
 
-  private fun conestTryEQK() = object : EqK<Conested<Kind<ForKleisli, ForTry>, Int>> {
-    override fun <A> Kind<Conested<Kind<ForKleisli, ForTry>, Int>, A>.eqK(other: Kind<Conested<Kind<ForKleisli, ForTry>, Int>, A>, EQ: Eq<A>): Boolean {
-      return this.counnest().run(1) == other.counnest().run(1)
-    }
-  }
-
-  fun conestTryGENK() = object : GenK<Conested<Kind<ForKleisli, ForTry>, Int>> {
-    override fun <A> genK(gen: Gen<A>): Gen<Kind<Conested<Kind<ForKleisli, ForTry>, Int>, A>> = gen.map {
-      Kleisli { it: Int ->
-        Try.just(it)
-      }.conest()
-    } as Gen<Kind<Conested<Kind<ForKleisli, ForTry>, Int>, A>>
-  }
-
   init {
-    fun <F, D> genK(genkF: GenK<F>) = object : GenK<KleisliPartialOf<F, D>> {
-      override fun <A> genK(gen: Gen<A>): Gen<Kind<KleisliPartialOf<F, D>, A>> = genkF.genK(gen).map { k ->
+    fun <D, F> genK(genkF: GenK<F>) = object : GenK<KleisliPartialOf<D, F>> {
+      override fun <A> genK(gen: Gen<A>): Gen<Kind<KleisliPartialOf<D, F>, A>> = genkF.genK(gen).map { k ->
         Kleisli { _: D -> k }
       }
     }
 
+    fun <D, F> Kleisli.Companion.eqK(EQKF: EqK<F>, d: D) = object : EqK<KleisliPartialOf<D, F>> {
+      override fun <A> Kind<KleisliPartialOf<D, F>, A>.eqK(other: Kind<KleisliPartialOf<D, F>, A>, EQ: Eq<A>): Boolean =
+        (this.fix() to other.fix()).let {
+          val ls = it.first.run(d)
+          val rs = it.second.run(d)
+
+          EQKF.liftEq(EQ).run {
+            ls.eqv(rs)
+          }
+        }
+    }
+
     val optionEQK = Kleisli.eqK(Option.eqK(), 0)
 
-    val ioEQK: EqK<Kind<Kind<ForKleisli, ForIO>, Int>> = Kleisli.eqK(IO.eqK(), 1)
+    val ioEQK: EqK<Kind<Kind<ForKleisli, Int>, ForIO>> = Kleisli.eqK(IO.eqK(), 1)
 
-    val tryEQK: EqK<Kind<Kind<ForKleisli, ForTry>, Int>> =
-      Kleisli.eqK(Try.eqK(), 1)
-
-    val constEQK: EqK<Kind<Kind<ForKleisli, Kind<ForConst, Int>>, Int>> = Kleisli.eqK(Const.eqK(Int.eq()), 1)
+    val constEQK: EqK<Kind<Kind<ForKleisli, Int>, Kind<ForConst, Int>>> = Kleisli.eqK(Const.eqK(Int.eq()), 1)
 
     testLaws(
       AlternativeLaws.laws(
-        Kleisli.alternative<ForOption, Int>(Option.alternative()),
-        genK<ForOption, Int>(Option.genK()),
+        Kleisli.alternative<Int, ForOption>(Option.alternative()),
+        genK<Int, ForOption>(Option.genK()),
         optionEQK
       ),
-      ConcurrentLaws.laws(
-        Kleisli.concurrent<ForIO, Int>(IO.concurrent()),
-        Kleisli.timer<ForIO, Int>(IO.concurrent()),
-        Kleisli.functor<ForIO, Int>(IO.functor()),
-        Kleisli.applicative<ForIO, Int>(IO.applicative()),
-        Kleisli.monad<ForIO, Int>(IO.monad()),
-        genK<ForIO, Int>(IO.genK()),
+      ConcurrentLaws.laws<KleisliPartialOf<Int, ForIO>>(
+        Kleisli.concurrent(IO.concurrent()),
+        Kleisli.timer(IO.concurrent()),
+        Kleisli.functor(IO.functor()),
+        Kleisli.applicative(IO.applicative()),
+        Kleisli.monad(IO.monad()),
+        genK(IO.genK()),
         ioEQK
       ),
-      ContravariantLaws.laws(Kleisli.contravariant(), conestTryGENK(), conestTryEQK()),
       DivisibleLaws.laws(
-        Kleisli.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
-        genK<ConstPartialOf<Int>, Int>(Const.genK(Gen.int())),
+        Kleisli.divisible<Int, ConstPartialOf<Int>>(Const.divisible(Int.monoid())),
+        genK<Int, ConstPartialOf<Int>>(Const.genK(Gen.int())),
         constEQK
       )
     )
 
     "andThen should continue sequence" {
-      val kleisli: Kleisli<ForId, Int, Int> = Kleisli { a: Int -> Id(a) }
+      val kleisli: Kleisli<Int, ForId, Int> = Kleisli { a: Int -> Id(a) }
 
       kleisli.andThen(Id.monad(), Id(3)).run(0) shouldBe Id(3)
 

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/kleisli.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/kleisli.kt
@@ -8,7 +8,6 @@ import arrow.core.Id
 import arrow.core.Tuple2
 import arrow.core.extensions.id.applicative.applicative
 import arrow.core.extensions.id.functor.functor
-import arrow.core.extensions.id.monad.monad
 import arrow.extension
 import arrow.mtl.ForKleisli
 import arrow.mtl.Kleisli
@@ -27,20 +26,15 @@ import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Apply
-import arrow.typeclasses.Conested
 import arrow.typeclasses.Contravariant
 import arrow.typeclasses.Decidable
 import arrow.typeclasses.Divide
 import arrow.typeclasses.Divisible
-import arrow.typeclasses.Eq
-import arrow.typeclasses.EqK
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadError
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.MonadThrow
-import arrow.typeclasses.conest
-import arrow.typeclasses.counnest
 import arrow.undocumented
 
 @extension


### PR DESCRIPTION
Changed `Kleisli<F, D, A>` -> `Kleisli<D, F, A>`.

Same reasons as #23 