### PR TITLE
EitherT MonadTrans instance and generics reorder

### DIFF
--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
@@ -38,7 +38,7 @@ import kotlin.coroutines.CoroutineContext
 
 @extension
 @undocumented
-interface EitherTBracket<F, L> : Bracket<EitherTPartialOf<F, L>, Throwable>, EitherTMonadThrow<F, L> {
+interface EitherTBracket<L, F> : Bracket<EitherTPartialOf<L, F>, Throwable>, EitherTMonadThrow<L, F> {
 
   fun MDF(): MonadDefer<F>
 
@@ -46,11 +46,11 @@ interface EitherTBracket<F, L> : Bracket<EitherTPartialOf<F, L>, Throwable>, Eit
 
   override fun AE(): ApplicativeError<F, Throwable> = MDF()
 
-  override fun <A, B> EitherTOf<F, L, A>.bracketCase(
-    release: (A, ExitCase<Throwable>) -> EitherTOf<F, L, Unit>,
-    use: (A) -> EitherTOf<F, L, B>
-  ): EitherT<F, L, B> = MDF().run {
-    EitherT.liftF<F, L, Ref<F, Option<L>>>(this, Ref(None)).flatMap { ref ->
+  override fun <A, B> EitherTOf<L, F, A>.bracketCase(
+    release: (A, ExitCase<Throwable>) -> EitherTOf<L, F, Unit>,
+    use: (A) -> EitherTOf<L, F, B>
+  ): EitherT<L, F, B> = MDF().run {
+    EitherT.liftF<L, F, Ref<F, Option<L>>>(this, Ref(None)).flatMap { ref ->
       EitherT(value().bracketCase(use = { either ->
         when (either) {
           is Either.Right -> use(either.b).value()
@@ -84,53 +84,53 @@ interface EitherTBracket<F, L> : Bracket<EitherTPartialOf<F, L>, Throwable>, Eit
 
 @extension
 @undocumented
-interface EitherTMonadDefer<F, L> : MonadDefer<EitherTPartialOf<F, L>>, EitherTBracket<F, L> {
+interface EitherTMonadDefer<L, F> : MonadDefer<EitherTPartialOf<L, F>>, EitherTBracket<L, F> {
 
   override fun MDF(): MonadDefer<F>
 
-  override fun <A> defer(fa: () -> EitherTOf<F, L, A>): EitherT<F, L, A> =
+  override fun <A> defer(fa: () -> EitherTOf<L, F, A>): EitherT<L, F, A> =
     EitherT(MDF().defer { fa().value() })
 }
 
 @extension
 @undocumented
-interface EitherTAsync<F, L> : Async<EitherTPartialOf<F, L>>, EitherTMonadDefer<F, L> {
+interface EitherTAsync<L, F> : Async<EitherTPartialOf<L, F>>, EitherTMonadDefer<L, F> {
 
   fun ASF(): Async<F>
 
   override fun MDF(): MonadDefer<F> = ASF()
 
-  override fun <A> async(fa: Proc<A>): EitherT<F, L, A> = ASF().run {
+  override fun <A> async(fa: Proc<A>): EitherT<L, F, A> = ASF().run {
     EitherT.liftF(this, async(fa))
   }
 
-  override fun <A> asyncF(k: ProcF<EitherTPartialOf<F, L>, A>): EitherT<F, L, A> = ASF().run {
+  override fun <A> asyncF(k: ProcF<EitherTPartialOf<L, F>, A>): EitherT<L, F, A> = ASF().run {
     EitherT.liftF(this, asyncF { cb -> k(cb).value().unit() })
   }
 
-  override fun <A> EitherTOf<F, L, A>.continueOn(ctx: CoroutineContext): EitherT<F, L, A> = ASF().run {
+  override fun <A> EitherTOf<L, F, A>.continueOn(ctx: CoroutineContext): EitherT<L, F, A> = ASF().run {
     EitherT(value().continueOn(ctx))
   }
 }
 
-interface EitherTConcurrent<F, L> : Concurrent<EitherTPartialOf<F, L>>, EitherTAsync<F, L> {
+interface EitherTConcurrent<L, F> : Concurrent<EitherTPartialOf<L, F>>, EitherTAsync<L, F> {
 
   fun CF(): Concurrent<F>
 
   override fun ASF(): Async<F> = CF()
 
-  override fun dispatchers(): Dispatchers<EitherTPartialOf<F, L>> =
-    CF().dispatchers() as Dispatchers<EitherTPartialOf<F, L>>
+  override fun dispatchers(): Dispatchers<EitherTPartialOf<L, F>> =
+    CF().dispatchers() as Dispatchers<EitherTPartialOf<L, F>>
 
-  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<EitherTPartialOf<F, L>>): EitherT<F, L, A> = CF().run {
+  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<EitherTPartialOf<L, F>>): EitherT<L, F, A> = CF().run {
     EitherT.liftF(this, cancelable { cb -> k(cb).value().map { Unit } })
   }
 
-  override fun <A> EitherTOf<F, L, A>.fork(ctx: CoroutineContext): EitherT<F, L, Fiber<EitherTPartialOf<F, L>, A>> = CF().run {
+  override fun <A> EitherTOf<L, F, A>.fork(ctx: CoroutineContext): EitherT<L, F, Fiber<EitherTPartialOf<L, F>, A>> = CF().run {
     EitherT.liftF(this, value().fork(ctx).map(::fiberT))
   }
 
-  override fun <A, B, C> CoroutineContext.parMapN(fa: EitherTOf<F, L, A>, fb: EitherTOf<F, L, B>, f: (A, B) -> C): Kind<EitherTPartialOf<F, L>, C> = CF().run {
+  override fun <A, B, C> CoroutineContext.parMapN(fa: EitherTOf<L, F, A>, fb: EitherTOf<L, F, B>, f: (A, B) -> C): Kind<EitherTPartialOf<L, F>, C> = CF().run {
     EitherT(parMapN(fa.value(), fb.value()) { a, b ->
       a.flatMap { aa ->
         b.map { bb -> f(aa, bb) }
@@ -138,7 +138,7 @@ interface EitherTConcurrent<F, L> : Concurrent<EitherTPartialOf<F, L>>, EitherTA
     })
   }
 
-  override fun <A, B, C, D> CoroutineContext.parMapN(fa: EitherTOf<F, L, A>, fb: EitherTOf<F, L, B>, fc: EitherTOf<F, L, C>, f: (A, B, C) -> D): EitherT<F, L, D> = CF().run {
+  override fun <A, B, C, D> CoroutineContext.parMapN(fa: EitherTOf<L, F, A>, fb: EitherTOf<L, F, B>, fc: EitherTOf<L, F, C>, f: (A, B, C) -> D): EitherT<L, F, D> = CF().run {
     EitherT(parMapN(fa.value(), fb.value(), fc.value()) { a, b, c ->
       a.flatMap { aa ->
         b.flatMap { bb ->
@@ -150,8 +150,8 @@ interface EitherTConcurrent<F, L> : Concurrent<EitherTPartialOf<F, L>>, EitherTA
     })
   }
 
-  override fun <A, B> CoroutineContext.racePair(fa: EitherTOf<F, L, A>, fb: EitherTOf<F, L, B>): EitherT<F, L, RacePair<EitherTPartialOf<F, L>, A, B>> = CF().run {
-    val racePair: Kind<F, Either<L, RacePair<EitherTPartialOf<F, L>, A, B>>> =
+  override fun <A, B> CoroutineContext.racePair(fa: EitherTOf<L, F, A>, fb: EitherTOf<L, F, B>): EitherT<L, F, RacePair<EitherTPartialOf<L, F>, A, B>> = CF().run {
+    val racePair: Kind<F, Either<L, RacePair<EitherTPartialOf<L, F>, A, B>>> =
       racePair(fa.value(), fb.value()).flatMap { res: RacePair<F, Either<L, A>, Either<L, B>> ->
         when (res) {
           is RacePair.First -> when (val winner = res.winner) {
@@ -168,11 +168,11 @@ interface EitherTConcurrent<F, L> : Concurrent<EitherTPartialOf<F, L>>, EitherTA
   }
 
   override fun <A, B, C> CoroutineContext.raceTriple(
-    fa: EitherTOf<F, L, A>,
-    fb: EitherTOf<F, L, B>,
-    fc: EitherTOf<F, L, C>
-  ): EitherT<F, L, RaceTriple<EitherTPartialOf<F, L>, A, B, C>> = CF().run {
-    val raceTriple: Kind<F, Either<L, RaceTriple<EitherTPartialOf<F, L>, A, B, C>>> =
+    fa: EitherTOf<L, F, A>,
+    fb: EitherTOf<L, F, B>,
+    fc: EitherTOf<L, F, C>
+  ): EitherT<L, F, RaceTriple<EitherTPartialOf<L, F>, A, B, C>> = CF().run {
+    val raceTriple: Kind<F, Either<L, RaceTriple<EitherTPartialOf<L, F>, A, B, C>>> =
       raceTriple(fa.value(), fb.value(), fc.value()).flatMap { res: RaceTriple<F, Either<L, A>, Either<L, B>, Either<L, C>> ->
         when (res) {
           is RaceTriple.First -> when (val winner = res.winner) {
@@ -192,23 +192,23 @@ interface EitherTConcurrent<F, L> : Concurrent<EitherTPartialOf<F, L>>, EitherTA
     EitherT(raceTriple)
   }
 
-  fun <A> fiberT(fiber: Fiber<F, Either<L, A>>): Fiber<EitherTPartialOf<F, L>, A> =
+  fun <A> fiberT(fiber: Fiber<F, Either<L, A>>): Fiber<EitherTPartialOf<L, F>, A> =
     Fiber(EitherT(fiber.join()), EitherT.liftF(ASF(), fiber.cancel()))
 }
 
-fun <F, L> EitherT.Companion.concurrent(CF: Concurrent<F>): Concurrent<EitherTPartialOf<F, L>> =
-  object : EitherTConcurrent<F, L> {
+fun <L, F> EitherT.Companion.concurrent(CF: Concurrent<F>): Concurrent<EitherTPartialOf<L, F>> =
+  object : EitherTConcurrent<L, F> {
     override fun CF(): Concurrent<F> = CF
   }
 
-fun <F, L> EitherT.Companion.timer(CF: Concurrent<F>): Timer<EitherTPartialOf<F, L>> =
-  Timer(concurrent<F, L>(CF))
+fun <L, F> EitherT.Companion.timer(CF: Concurrent<F>): Timer<EitherTPartialOf<L, F>> =
+  Timer(concurrent<L, F>(CF))
 
 @extension
-interface EitherTMonadIO<F, L> : MonadIO<EitherTPartialOf<F, L>>, EitherTMonad<F, L> {
+interface EitherTMonadIO<L, F> : MonadIO<EitherTPartialOf<L, F>>, EitherTMonad<L, F> {
   fun FIO(): MonadIO<F>
   override fun MF(): Monad<F> = FIO()
-  override fun <A> IO<A>.liftIO(): Kind<EitherTPartialOf<F, L>, A> = FIO().run {
+  override fun <A> IO<A>.liftIO(): Kind<EitherTPartialOf<L, F>, A> = FIO().run {
     EitherT.liftF(this, liftIO())
   }
 }

--- a/arrow-incubator-test/src/main/kotlin/arrow/test/generators/GenK.kt
+++ b/arrow-incubator-test/src/main/kotlin/arrow/test/generators/GenK.kt
@@ -110,12 +110,10 @@ fun <A> Const.Companion.genK(genA: Gen<A>) = object : GenK<ConstPartialOf<A>> {
     }
 }
 
-fun <F, L> EitherT.Companion.genK(genkF: GenK<F>, genL: Gen<L>) =
-  object : GenK<EitherTPartialOf<F, L>> {
-    override fun <R> genK(gen: Gen<R>): Gen<Kind<EitherTPartialOf<F, L>, R>> =
-      genkF.genK(Gen.either(genL, gen)).map {
-        EitherT(it)
-      }
+fun <L, F> EitherT.Companion.genK(genkF: GenK<F>, genL: Gen<L>) =
+  object : GenK<EitherTPartialOf<L, F>> {
+    override fun <R> genK(gen: Gen<R>): Gen<Kind<EitherTPartialOf<L, F>, R>> =
+      genkF.genK(Gen.either(genL, gen)).map { EitherT(it) }
   }
 
 fun <F, G> GenK<F>.nested(GENKG: GenK<G>): GenK<Nested<F, G>> = object : GenK<Nested<F, G>> {

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/EitherT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/EitherT.kt
@@ -10,26 +10,26 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 
-fun <F, A, B> EitherTOf<F, A, B>.value(): Kind<F, Either<A, B>> = fix().value()
+fun <A, F, B> EitherTOf<A, F, B>.value(): Kind<F, Either<A, B>> = fix().value()
 
 /**
- * [EitherT]`<F, A, B>` is a light wrapper on an `F<`[Either]`<A, B>>` with some
+ * [EitherT]`<A, F, B>` is a light wrapper on an `F<`[Either]`<A, B>>` with some
  * convenient methods for working with this nested structure.
  *
  * It may also be said that [EitherT] is a monad transformer for [Either].
  */
 @higherkind
-data class EitherT<F, A, B>(private val value: Kind<F, Either<A, B>>) : EitherTOf<F, A, B>, EitherTKindedJ<F, A, B> {
+data class EitherT<A, F, B>(private val value: Kind<F, Either<A, B>>) : EitherTOf<A, F, B>, EitherTKindedJ<A, F, B> {
 
   companion object {
 
-    operator fun <F, A, B> invoke(value: Kind<F, Either<A, B>>): EitherT<F, A, B> =
+    operator fun <A, F, B> invoke(value: Kind<F, Either<A, B>>): EitherT<A, F, B> =
       EitherT(value)
 
-    fun <F, A, B> just(MF: Applicative<F>, b: B): EitherT<F, A, B> =
+    fun <A, F, B> just(MF: Applicative<F>, b: B): EitherT<A, F, B> =
       right(MF, b)
 
-    fun <F, L, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> EitherTOf<F, L, Either<A, B>>): EitherT<F, L, B> =
+    fun <L, F, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> EitherTOf<L, F, Either<A, B>>): EitherT<L, F, B> =
       EitherT(MF.tailRecM(a) {
         val value = f(it).value()
         MF.run {
@@ -48,16 +48,16 @@ data class EitherT<F, A, B>(private val value: Kind<F, Either<A, B>>) : EitherTO
         }
       })
 
-    fun <F, A, B> right(MF: Applicative<F>, b: B): EitherT<F, A, B> =
+    fun <A, F, B> right(MF: Applicative<F>, b: B): EitherT<A, F, B> =
       EitherT(MF.just(Right(b)))
 
-    fun <F, A, B> left(MF: Applicative<F>, a: A): EitherT<F, A, B> =
+    fun <A, F, B> left(MF: Applicative<F>, a: A): EitherT<A, F, B> =
       EitherT(MF.just(Left(a)))
 
-    fun <F, A, B> fromEither(AP: Applicative<F>, value: Either<A, B>): EitherT<F, A, B> =
+    fun <A, F, B> fromEither(AP: Applicative<F>, value: Either<A, B>): EitherT<A, F, B> =
       EitherT(AP.just(value))
 
-    fun <F, A, B> liftF(FF: Functor<F>, fa: Kind<F, B>): EitherT<F, A, B> = FF.run {
+    fun <A, F, B> liftF(FF: Functor<F>, fa: Kind<F, B>): EitherT<A, F, B> = FF.run {
       EitherT(fa.map(::Right))
     }
   }
@@ -68,28 +68,28 @@ data class EitherT<F, A, B>(private val value: Kind<F, Either<A, B>>) : EitherTO
     value().map { either -> either.fold(l, r) }
   }
 
-  fun <C> flatMap(MF: Monad<F>, f: (B) -> EitherTOf<F, A, C>): EitherT<F, A, C> =
+  fun <C> flatMap(MF: Monad<F>, f: (B) -> EitherTOf<A, F, C>): EitherT<A, F, C> =
     flatMapF(MF) { f(it).value() }
 
-  fun <C> flatMapF(MF: Monad<F>, f: (B) -> Kind<F, Either<A, C>>): EitherT<F, A, C> = MF.run {
+  fun <C> flatMapF(MF: Monad<F>, f: (B) -> Kind<F, Either<A, C>>): EitherT<A, F, C> = MF.run {
     EitherT(value.flatMap { either -> either.fold({ MF.just(Left(it)) }, { f(it) }) })
   }
 
   fun <C> cata(FF: Functor<F>, l: (A) -> C, r: (B) -> C): Kind<F, C> =
     fold(FF, l, r)
 
-  fun <C> liftF(FF: Functor<F>, fa: Kind<F, C>): EitherT<F, A, C> = FF.run {
+  fun <C> liftF(FF: Functor<F>, fa: Kind<F, C>): EitherT<A, F, C> = FF.run {
     EitherT(fa.map { Right(it) })
   }
 
-  fun <C> semiflatMap(MF: Monad<F>, f: (B) -> Kind<F, C>): EitherT<F, A, C> =
+  fun <C> semiflatMap(MF: Monad<F>, f: (B) -> Kind<F, C>): EitherT<A, F, C> =
     flatMap(MF) { liftF(MF, f(it)) }
 
-  fun <C> map(FF: Functor<F>, f: (B) -> C): EitherT<F, A, C> = FF.run {
+  fun <C> map(FF: Functor<F>, f: (B) -> C): EitherT<A, F, C> = FF.run {
     EitherT(value.map { it.map(f) })
   }
 
-  fun <C> mapLeft(FF: Functor<F>, f: (A) -> C): EitherT<F, C, B> = FF.run {
+  fun <C> mapLeft(FF: Functor<F>, f: (A) -> C): EitherT<C, F, B> = FF.run {
     EitherT(value.map { it.mapLeft(f) })
   }
 
@@ -97,18 +97,18 @@ data class EitherT<F, A, B>(private val value: Kind<F, Either<A, B>>) : EitherTO
     value.map { it.exists(p) }
   }
 
-  fun <C, D> transform(FF: Functor<F>, f: (Either<A, B>) -> Either<C, D>): EitherT<F, C, D> = FF.run {
+  fun <C, D> transform(FF: Functor<F>, f: (Either<A, B>) -> Either<C, D>): EitherT<C, F, D> = FF.run {
     EitherT(value.map { f(it) })
   }
 
-  fun <C> subflatMap(FF: Functor<F>, f: (B) -> Either<A, C>): EitherT<F, A, C> =
+  fun <C> subflatMap(FF: Functor<F>, f: (B) -> Either<A, C>): EitherT<A, F, C> =
     transform(FF) { it.flatMap(f = f) }
 
   fun toOptionT(FF: Functor<F>): OptionT<F, B> = FF.run {
     OptionT(value.map { it.toOption() })
   }
 
-  fun combineK(MF: Monad<F>, y: EitherTOf<F, A, B>): EitherT<F, A, B> = MF.run {
+  fun combineK(MF: Monad<F>, y: EitherTOf<A, F, B>): EitherT<A, F, B> = MF.run {
     EitherT(value.flatMap {
       when (it) {
         is Either.Left -> y.value()
@@ -117,7 +117,7 @@ data class EitherT<F, A, B>(private val value: Kind<F, Either<A, B>>) : EitherTO
     })
   }
 
-  fun <C> ap(AF: Applicative<F>, ff: EitherTOf<F, A, (B) -> C>): EitherT<F, A, C> =
+  fun <C> ap(AF: Applicative<F>, ff: EitherTOf<A, F, (B) -> C>): EitherT<A, F, C> =
     EitherT(AF.mapN(ff.value(), value) { (a, b) ->
       b.flatMap { bb ->
         a.map { f -> f(bb) }

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/OptionT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/OptionT.kt
@@ -124,9 +124,9 @@ data class OptionT<F, A>(private val value: Kind<F, Option<A>>) : OptionTOf<F, A
 
   fun <B> subflatMap(FF: Functor<F>, f: (A) -> OptionOf<B>): OptionT<F, B> = transform(FF) { it.flatMap(f) }
 
-  fun <R> toLeft(FF: Functor<F>, default: () -> R): EitherT<F, A, R> =
+  fun <R> toLeft(FF: Functor<F>, default: () -> R): EitherT<A, F, R> =
     EitherT(cata(FF, { Right(default()) }, { Left(it) }))
 
-  fun <L> toRight(FF: Functor<F>, default: () -> L): EitherT<F, L, A> =
+  fun <L> toRight(FF: Functor<F>, default: () -> L): EitherT<L, F, A> =
     EitherT(cata(FF, { Left(default()) }, { Right(it) }))
 }

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
@@ -26,6 +26,12 @@ import arrow.fx.extensions.io.functor.functor
 import arrow.fx.extensions.io.monad.monad
 import arrow.fx.mtl.concurrent
 import arrow.fx.mtl.timer
+import arrow.mtl.extensions.eithert.alternative.alternative
+import arrow.mtl.extensions.eithert.applicative.applicative
+import arrow.mtl.extensions.eithert.divisible.divisible
+import arrow.mtl.extensions.eithert.eqK.eqK
+import arrow.mtl.extensions.eithert.functor.functor
+import arrow.mtl.extensions.eithert.monad.monad
 import arrow.mtl.extensions.eithert.semigroupK.semigroupK
 import arrow.mtl.extensions.eithert.traverse.traverse
 import arrow.test.UnitSpec

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
@@ -26,12 +26,6 @@ import arrow.fx.extensions.io.functor.functor
 import arrow.fx.extensions.io.monad.monad
 import arrow.fx.mtl.concurrent
 import arrow.fx.mtl.timer
-import arrow.mtl.extensions.eithert.alternative.alternative
-import arrow.mtl.extensions.eithert.applicative.applicative
-import arrow.mtl.extensions.eithert.divisible.divisible
-import arrow.mtl.extensions.eithert.eqK.eqK
-import arrow.mtl.extensions.eithert.functor.functor
-import arrow.mtl.extensions.eithert.monad.monad
 import arrow.mtl.extensions.eithert.semigroupK.semigroupK
 import arrow.mtl.extensions.eithert.traverse.traverse
 import arrow.test.UnitSpec
@@ -49,15 +43,15 @@ import io.kotlintest.properties.forAll
 class EitherTTest : UnitSpec() {
 
   init {
-    val idEQK: EqK<Kind<Kind<ForEitherT, ForId>, Int>> = EitherT.eqK(Id.eqK(), Int.eq())
+    val idEQK: EqK<Kind<Kind<ForEitherT, Int>, ForId>> = EitherT.eqK(Id.eqK(), Int.eq())
 
-    val ioEQK: EqK<Kind<Kind<ForEitherT, ForIO>, String>> = EitherT.eqK(IO.eqK(), Eq.any())
+    val ioEQK: EqK<Kind<Kind<ForEitherT, String>, ForIO>> = EitherT.eqK(IO.eqK(), Eq.any())
 
-    val constEQK: EqK<Kind<Kind<ForEitherT, Kind<ForConst, Int>>, Int>> = EitherT.eqK(Const.eqK(Int.eq()), Int.eq())
+    val constEQK: EqK<Kind<Kind<ForEitherT, Int>, Kind<ForConst, Int>>> = EitherT.eqK(Const.eqK(Int.eq()), Int.eq())
 
     testLaws(
       DivisibleLaws.laws(
-        EitherT.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
+        EitherT.divisible<Int, ConstPartialOf<Int>>(Const.divisible(Int.monoid())),
         EitherT.genK(Const.genK(Gen.int()), Gen.int()),
         constEQK
       ),
@@ -68,9 +62,9 @@ class EitherTTest : UnitSpec() {
         idEQK
       ),
 
-      ConcurrentLaws.laws<EitherTPartialOf<ForIO, String>>(
+      ConcurrentLaws.laws<EitherTPartialOf<String, ForIO>>(
         EitherT.concurrent(IO.concurrent()),
-        EitherT.timer<ForIO, String>(IO.concurrent()),
+        EitherT.timer(IO.concurrent()),
         EitherT.functor(IO.functor()),
         EitherT.applicative(IO.applicative()),
         EitherT.monad(IO.monad()),
@@ -78,12 +72,12 @@ class EitherTTest : UnitSpec() {
         ioEQK
       ),
 
-      TraverseLaws.laws(EitherT.traverse<ForId, Int>(Id.traverse()),
+      TraverseLaws.laws(EitherT.traverse<Int, ForId>(Id.traverse()),
         EitherT.genK(Id.genK(), Gen.int()),
         idEQK),
 
       SemigroupKLaws.laws(
-        EitherT.semigroupK<ForId, Int>(Id.monad()),
+        EitherT.semigroupK<Int, ForId>(Id.monad()),
         EitherT.genK(Id.genK(), Gen.int()),
         idEQK
       )

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/OptionTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/OptionTTest.kt
@@ -125,13 +125,13 @@ class OptionTTest : UnitSpec() {
       forAll { a: Int, b: String ->
         OptionT
           .fromOption(NELM, Some(a))
-          .toLeft(NELM) { b } == EitherT.left<ForNonEmptyList, Int, String>(NELM, a)
+          .toLeft(NELM) { b } == EitherT.left<Int, ForNonEmptyList, String>(NELM, a)
       }
     }
 
     "toLeft for None should build a correct EitherT" {
       forAll { b: String ->
-        OptionT.fromOption<ForNonEmptyList, Int>(NELM, None).toLeft(NELM) { b } == EitherT.right<ForNonEmptyList, Int, String>(NELM, b)
+        OptionT.fromOption<ForNonEmptyList, Int>(NELM, None).toLeft(NELM) { b } == EitherT.right<Int, ForNonEmptyList, String>(NELM, b)
       }
     }
 
@@ -139,13 +139,13 @@ class OptionTTest : UnitSpec() {
       forAll { a: Int, b: String ->
         OptionT
           .fromOption(NELM, Some(b))
-          .toRight(NELM) { a } == EitherT.right<ForNonEmptyList, Int, String>(NELM, b)
+          .toRight(NELM) { a } == EitherT.right<Int, ForNonEmptyList, String>(NELM, b)
       }
     }
 
     "toRight for None should build a correct EitherT" {
       forAll { a: Int ->
-        OptionT.fromOption<ForNonEmptyList, String>(NELM, None).toRight(NELM) { a } == EitherT.left<ForNonEmptyList, Int, String>(NELM, a)
+        OptionT.fromOption<ForNonEmptyList, String>(NELM, None).toRight(NELM) { a } == EitherT.left<Int, ForNonEmptyList, String>(NELM, a)
       }
     }
   }

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
@@ -1,6 +1,7 @@
 package arrow.mtl.extensions
 
 import arrow.Kind
+import arrow.Kind2
 import arrow.core.Either
 import arrow.core.EitherPartialOf
 import arrow.core.Eval
@@ -19,9 +20,11 @@ import arrow.extension
 import arrow.mtl.EitherT
 import arrow.mtl.EitherTOf
 import arrow.mtl.EitherTPartialOf
+import arrow.mtl.ForEitherT
 import arrow.mtl.extensions.eithert.monadThrow.monadThrow
 import arrow.mtl.fix
 import arrow.mtl.typeclasses.ComposedTraverse
+import arrow.mtl.typeclasses.MonadTrans
 import arrow.mtl.typeclasses.Nested
 import arrow.mtl.typeclasses.compose
 import arrow.mtl.typeclasses.unnest
@@ -49,29 +52,29 @@ import arrow.undocumented
 
 @extension
 @undocumented
-interface EitherTFunctor<F, L> : Functor<EitherTPartialOf<F, L>> {
+interface EitherTFunctor<L, F> : Functor<EitherTPartialOf<L, F>> {
 
   fun FF(): Functor<F>
 
-  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.map(f: (A) -> B): EitherT<L, F, B> =
     fix().map(FF(), f)
 }
 
 @extension
 @undocumented
-interface EitherTApply<F, L> : Apply<EitherTPartialOf<F, L>>, EitherTFunctor<F, L> {
+interface EitherTApply<L, F> : Apply<EitherTPartialOf<L, F>>, EitherTFunctor<L, F> {
 
   fun AF(): Applicative<F>
 
   override fun FF(): Functor<F> = AF()
 
-  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.map(f: (A) -> B): EitherT<L, F, B> =
     fix().map(AF(), f)
 
-  override fun <A, B> EitherTOf<F, L, A>.ap(ff: EitherTOf<F, L, (A) -> B>): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.ap(ff: EitherTOf<L, F, (A) -> B>): EitherT<L, F, B> =
     fix().ap(AF(), ff)
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<F, L>, (A) -> B>): Kind<EitherTPartialOf<F, L>, B> =
+  override fun <A, B> Kind<EitherTPartialOf<L, F>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<L, F>, (A) -> B>): Kind<EitherTPartialOf<L, F>, B> =
     EitherT(
       AF().run {
         fix().value().lazyAp { ff().value().map { r -> { l: Either<L, A> -> l.ap(r) } } }
@@ -81,40 +84,40 @@ interface EitherTApply<F, L> : Apply<EitherTPartialOf<F, L>>, EitherTFunctor<F, 
 
 @extension
 @undocumented
-interface EitherTApplicative<F, L> : Applicative<EitherTPartialOf<F, L>>, EitherTApply<F, L> {
+interface EitherTApplicative<L, F> : Applicative<EitherTPartialOf<L, F>>, EitherTApply<L, F> {
 
   override fun AF(): Applicative<F>
 
   override fun FF(): Functor<F> = AF()
 
-  override fun <A> just(a: A): EitherT<F, L, A> =
+  override fun <A> just(a: A): EitherT<L, F, A> =
     EitherT.just(AF(), a)
 
-  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.map(f: (A) -> B): EitherT<L, F, B> =
     fix().map(AF(), f)
 }
 
 @extension
 @undocumented
-interface EitherTMonad<F, L> : Monad<EitherTPartialOf<F, L>>, EitherTApplicative<F, L> {
+interface EitherTMonad<L, F> : Monad<EitherTPartialOf<L, F>>, EitherTApplicative<L, F> {
 
   fun MF(): Monad<F>
 
   override fun AF(): Applicative<F> = MF()
 
-  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.map(f: (A) -> B): EitherT<L, F, B> =
     fix().map(MF(), f)
 
-  override fun <A, B> EitherTOf<F, L, A>.ap(ff: EitherTOf<F, L, (A) -> B>): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.ap(ff: EitherTOf<L, F, (A) -> B>): EitherT<L, F, B> =
     fix().ap(MF(), ff)
 
-  override fun <A, B> EitherTOf<F, L, A>.flatMap(f: (A) -> EitherTOf<F, L, B>): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.flatMap(f: (A) -> EitherTOf<L, F, B>): EitherT<L, F, B> =
     fix().flatMap(MF(), f)
 
-  override fun <A, B> tailRecM(a: A, f: (A) -> EitherTOf<F, L, Either<A, B>>): EitherT<F, L, B> =
+  override fun <A, B> tailRecM(a: A, f: (A) -> EitherTOf<L, F, Either<A, B>>): EitherT<L, F, B> =
     EitherT.tailRecM(MF(), a, f)
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<F, L>, (A) -> B>): Kind<EitherTPartialOf<F, L>, B> =
+  override fun <A, B> Kind<EitherTPartialOf<L, F>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<L, F>, (A) -> B>): Kind<EitherTPartialOf<L, F>, B> =
     EitherT(
       AF().run {
         fix().value().lazyAp { ff().value().map { r -> { l: Either<L, A> -> l.ap(r) } } }
@@ -124,57 +127,57 @@ interface EitherTMonad<F, L> : Monad<EitherTPartialOf<F, L>>, EitherTApplicative
 
 @extension
 @undocumented
-interface EitherTApplicativeError<F, L, E> : ApplicativeError<EitherTPartialOf<F, L>, E>, EitherTApplicative<F, L> {
+interface EitherTApplicativeError<L, F, E> : ApplicativeError<EitherTPartialOf<L, F>, E>, EitherTApplicative<L, F> {
 
   fun AE(): ApplicativeError<F, E>
 
   override fun AF(): Applicative<F> = AE()
 
-  override fun <A> raiseError(e: E): EitherT<F, L, A> =
+  override fun <A> raiseError(e: E): EitherT<L, F, A> =
     EitherT.liftF(AE(), AE().raiseError(e))
 
-  override fun <A> EitherTOf<F, L, A>.handleErrorWith(f: (E) -> EitherTOf<F, L, A>): EitherT<F, L, A> = AE().run {
+  override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (E) -> EitherTOf<L, F, A>): EitherT<L, F, A> = AE().run {
     EitherT(value().handleErrorWith { l -> f(l).value() })
   }
 }
 
 @extension
 @undocumented
-interface EitherTMonadError<F, L, E> : MonadError<EitherTPartialOf<F, L>, E>, EitherTApplicativeError<F, L, E>, EitherTMonad<F, L> {
+interface EitherTMonadError<L, F, E> : MonadError<EitherTPartialOf<L, F>, E>, EitherTApplicativeError<L, F, E>, EitherTMonad<L, F> {
   override fun MF(): Monad<F>
   override fun AE(): ApplicativeError<F, E>
   override fun AF(): Applicative<F> = MF()
 }
 
-fun <F, L, E> EitherT.Companion.monadError(ME: MonadError<F, E>): MonadError<EitherTPartialOf<F, L>, E> =
-  object : EitherTMonadError<F, L, E> {
+fun <L, F, E> EitherT.Companion.monadError(ME: MonadError<F, E>): MonadError<EitherTPartialOf<L, F>, E> =
+  object : EitherTMonadError<L, F, E> {
     override fun MF(): Monad<F> = ME
     override fun AE(): ApplicativeError<F, E> = ME
   }
 
 @extension
 @undocumented
-interface EitherTMonadThrow<F, L> : MonadThrow<EitherTPartialOf<F, L>>, EitherTMonadError<F, L, Throwable> {
+interface EitherTMonadThrow<L, F> : MonadThrow<EitherTPartialOf<L, F>>, EitherTMonadError<L, F, Throwable> {
   override fun MF(): Monad<F>
   override fun AE(): ApplicativeError<F, Throwable>
 }
 
 @extension
 @undocumented
-interface EitherTFoldable<F, L> : Foldable<EitherTPartialOf<F, L>> {
+interface EitherTFoldable<L, F> : Foldable<EitherTPartialOf<L, F>> {
 
   fun FFF(): Foldable<F>
 
-  override fun <B, C> EitherTOf<F, L, B>.foldLeft(b: C, f: (C, B) -> C): C =
+  override fun <B, C> EitherTOf<L, F, B>.foldLeft(b: C, f: (C, B) -> C): C =
     fix().foldLeft(FFF(), b, f)
 
-  override fun <B, C> EitherTOf<F, L, B>.foldRight(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
+  override fun <B, C> EitherTOf<L, F, B>.foldRight(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fix().foldRight(FFF(), lb, f)
 }
 
 @extension
 @undocumented
-interface EitherTTraverse<F, L> : Traverse<EitherTPartialOf<F, L>>, EitherTFunctor<F, L>, EitherTFoldable<F, L> {
+interface EitherTTraverse<L, F> : Traverse<EitherTPartialOf<L, F>>, EitherTFunctor<L, F>, EitherTFoldable<L, F> {
 
   fun TF(): Traverse<F>
 
@@ -182,28 +185,28 @@ interface EitherTTraverse<F, L> : Traverse<EitherTPartialOf<F, L>>, EitherTFunct
 
   override fun FFF(): Foldable<F> = TF()
 
-  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<L, F, A>.map(f: (A) -> B): EitherT<L, F, B> =
     fix().map(TF(), f)
 
-  override fun <G, B, C> EitherTOf<F, L, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, L, C>> =
+  override fun <G, B, C> EitherTOf<L, F, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<L, F, C>> =
     fix().traverse(TF(), AP, f)
 }
 
 @extension
 @undocumented
-interface EitherTSemigroupK<F, L> : SemigroupK<EitherTPartialOf<F, L>> {
+interface EitherTSemigroupK<L, F> : SemigroupK<EitherTPartialOf<L, F>> {
   fun MF(): Monad<F>
 
-  override fun <A> EitherTOf<F, L, A>.combineK(y: EitherTOf<F, L, A>): EitherT<F, L, A> =
+  override fun <A> EitherTOf<L, F, A>.combineK(y: EitherTOf<L, F, A>): EitherT<L, F, A> =
     fix().combineK(MF(), y)
 }
 
 @extension
 @undocumented
-interface EitherTContravariant<F, L> : Contravariant<EitherTPartialOf<F, L>> {
+interface EitherTContravariant<L, F> : Contravariant<EitherTPartialOf<L, F>> {
   fun CF(): Contravariant<F>
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.contramap(f: (B) -> A): Kind<EitherTPartialOf<F, L>, B> =
+  override fun <A, B> Kind<EitherTPartialOf<L, F>, A>.contramap(f: (B) -> A): Kind<EitherTPartialOf<L, F>, B> =
     EitherT(
       CF().run { value().contramap<Either<L, A>, Either<L, B>> { it.map(f) } }
     )
@@ -211,11 +214,11 @@ interface EitherTContravariant<F, L> : Contravariant<EitherTPartialOf<F, L>> {
 
 @extension
 @undocumented
-interface EitherTDivide<F, L> : Divide<EitherTPartialOf<F, L>>, EitherTContravariant<F, L> {
+interface EitherTDivide<L, F> : Divide<EitherTPartialOf<L, F>>, EitherTContravariant<L, F> {
   fun DF(): Divide<F>
   override fun CF(): Contravariant<F> = DF()
 
-  override fun <A, B, Z> divide(fa: Kind<EitherTPartialOf<F, L>, A>, fb: Kind<EitherTPartialOf<F, L>, B>, f: (Z) -> Tuple2<A, B>): Kind<EitherTPartialOf<F, L>, Z> =
+  override fun <A, B, Z> divide(fa: Kind<EitherTPartialOf<L, F>, A>, fb: Kind<EitherTPartialOf<L, F>, B>, f: (Z) -> Tuple2<A, B>): Kind<EitherTPartialOf<L, F>, Z> =
     EitherT(
       DF().divide(fa.value(), fb.value()) { either ->
         either.fold({ it.left() toT it.left() }, {
@@ -228,12 +231,12 @@ interface EitherTDivide<F, L> : Divide<EitherTPartialOf<F, L>>, EitherTContravar
 
 @extension
 @undocumented
-interface EitherTDivisibleInstance<F, L> : Divisible<EitherTPartialOf<F, L>>, EitherTDivide<F, L> {
+interface EitherTDivisibleInstance<L, F> : Divisible<EitherTPartialOf<L, F>>, EitherTDivide<L, F> {
 
   fun DFF(): Divisible<F>
   override fun DF(): Divide<F> = DFF()
 
-  override fun <A> conquer(): Kind<EitherTPartialOf<F, L>, A> =
+  override fun <A> conquer(): Kind<EitherTPartialOf<L, F>, A> =
     EitherT(
       DFF().conquer()
     )
@@ -241,12 +244,12 @@ interface EitherTDivisibleInstance<F, L> : Divisible<EitherTPartialOf<F, L>>, Ei
 
 @extension
 @undocumented
-interface EitherTDecidableInstance<F, L> : Decidable<EitherTPartialOf<F, L>>, EitherTDivisibleInstance<F, L> {
+interface EitherTDecidableInstance<L, F> : Decidable<EitherTPartialOf<L, F>>, EitherTDivisibleInstance<L, F> {
 
   fun DFFF(): Decidable<F>
   override fun DFF(): Divisible<F> = DFFF()
 
-  override fun <A, B, Z> choose(fa: Kind<EitherTPartialOf<F, L>, A>, fb: Kind<EitherTPartialOf<F, L>, B>, f: (Z) -> Either<A, B>): Kind<EitherTPartialOf<F, L>, Z> =
+  override fun <A, B, Z> choose(fa: Kind<EitherTPartialOf<L, F>, A>, fb: Kind<EitherTPartialOf<L, F>, B>, f: (Z) -> Either<A, B>): Kind<EitherTPartialOf<L, F>, Z> =
     EitherT(
       DFFF().choose(fa.value(), fb.value()) { either ->
         either.map(f).fold({ left ->
@@ -263,14 +266,14 @@ interface EitherTDecidableInstance<F, L> : Decidable<EitherTPartialOf<F, L>>, Ei
 }
 
 @extension
-interface EitherTAlternative<F, L> : Alternative<EitherTPartialOf<F, L>>, EitherTApplicative<F, L> {
+interface EitherTAlternative<L, F> : Alternative<EitherTPartialOf<L, F>>, EitherTApplicative<L, F> {
   override fun AF(): Applicative<F> = MF()
   fun MF(): Monad<F>
   fun ME(): Monoid<L>
 
-  override fun <A> empty(): Kind<EitherTPartialOf<F, L>, A> = EitherT(MF().just(ME().empty().left()))
+  override fun <A> empty(): Kind<EitherTPartialOf<L, F>, A> = EitherT(MF().just(ME().empty().left()))
 
-  override fun <A> Kind<EitherTPartialOf<F, L>, A>.orElse(b: Kind<EitherTPartialOf<F, L>, A>): Kind<EitherTPartialOf<F, L>, A> =
+  override fun <A> Kind<EitherTPartialOf<L, F>, A>.orElse(b: Kind<EitherTPartialOf<L, F>, A>): Kind<EitherTPartialOf<L, F>, A> =
     EitherT(
       MF().fx.monad {
         val l = !value()
@@ -288,46 +291,46 @@ interface EitherTAlternative<F, L> : Alternative<EitherTPartialOf<F, L>>, Either
     )
 }
 
-fun <F, A, B, C> EitherTOf<F, A, B>.foldLeft(FF: Foldable<F>, b: C, f: (C, B) -> C): C =
+fun <A, F, B, C> EitherTOf<A, F, B>.foldLeft(FF: Foldable<F>, b: C, f: (C, B) -> C): C =
   FF.compose(Either.foldable<A>()).foldLC(value(), b, f)
 
-fun <F, A, B, C> EitherTOf<F, A, B>.foldRight(FF: Foldable<F>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = FF.compose(Either.foldable<A>()).run {
+fun <A, F, B, C> EitherTOf<A, F, B>.foldRight(FF: Foldable<F>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = FF.compose(Either.foldable<A>()).run {
   value().foldRC(lb, f)
 }
 
-fun <F, A, B, G, C> EitherTOf<F, A, B>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, A, C>> {
+fun <A, F, B, G, C> EitherTOf<A, F, B>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<A, F, C>> {
   val fa: Kind<G, Kind<Nested<F, EitherPartialOf<A>>, C>> = ComposedTraverse(FF, Either.traverse<A>()).run { value().traverseC(f, GA) }
-  val mapper: (Kind<Nested<F, EitherPartialOf<A>>, C>) -> EitherT<F, A, C> = { nested -> EitherT(FF.run { nested.unnest().map { it.fix() } }) }
+  val mapper: (Kind<Nested<F, EitherPartialOf<A>>, C>) -> EitherT<A, F, C> = { nested -> EitherT(FF.run { nested.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }
 
-fun <F, G, A, B> EitherTOf<F, A, Kind<G, B>>.sequence(FF: Traverse<F>, GA: Applicative<G>): Kind<G, EitherT<F, A, B>> =
+fun <A, G, F, B> EitherTOf<A, F, Kind<G, B>>.sequence(FF: Traverse<F>, GA: Applicative<G>): Kind<G, EitherT<A, F, B>> =
   traverse(FF, GA, ::identity)
 
-fun <F, L> EitherT.Companion.applicativeError(MF: Monad<F>): ApplicativeError<EitherTPartialOf<F, L>, L> =
-  object : ApplicativeError<EitherTPartialOf<F, L>, L>, EitherTApplicative<F, L> {
+fun <L, F> EitherT.Companion.applicativeError(MF: Monad<F>): ApplicativeError<EitherTPartialOf<L, F>, L> =
+  object : ApplicativeError<EitherTPartialOf<L, F>, L>, EitherTApplicative<L, F> {
 
     override fun AF(): Applicative<F> = MF
 
-    override fun <A> raiseError(e: L): EitherTOf<F, L, A> =
+    override fun <A> raiseError(e: L): EitherTOf<L, F, A> =
       EitherT(MF.just(Left(e)))
 
-    override fun <A> EitherTOf<F, L, A>.handleErrorWith(f: (L) -> EitherTOf<F, L, A>): EitherT<F, L, A> =
+    override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (L) -> EitherTOf<L, F, A>): EitherT<L, F, A> =
       handleErrorWith(this, f, MF)
   }
 
-fun <F, L> EitherT.Companion.monadError(MF: Monad<F>): MonadError<EitherTPartialOf<F, L>, L> =
-  object : MonadError<EitherTPartialOf<F, L>, L>, EitherTMonad<F, L> {
+fun <L, F> EitherT.Companion.monadError(MF: Monad<F>): MonadError<EitherTPartialOf<L, F>, L> =
+  object : MonadError<EitherTPartialOf<L, F>, L>, EitherTMonad<L, F> {
     override fun MF(): Monad<F> = MF
 
-    override fun <A> raiseError(e: L): EitherTOf<F, L, A> =
+    override fun <A> raiseError(e: L): EitherTOf<L, F, A> =
       EitherT(MF.just(Left(e)))
 
-    override fun <A> EitherTOf<F, L, A>.handleErrorWith(f: (L) -> EitherTOf<F, L, A>): EitherT<F, L, A> =
+    override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (L) -> EitherTOf<L, F, A>): EitherT<L, F, A> =
       handleErrorWith(this, f, MF())
   }
 
-private fun <F, L, A> handleErrorWith(fa: EitherTOf<F, L, A>, f: (L) -> EitherTOf<F, L, A>, MF: Monad<F>): EitherT<F, L, A> =
+private fun <L, F, A> handleErrorWith(fa: EitherTOf<L, F, A>, f: (L) -> EitherTOf<L, F, A>, MF: Monad<F>): EitherT<L, F, A> =
   MF.run {
     EitherT(fa.value().flatMap {
       when (it) {
@@ -337,19 +340,25 @@ private fun <F, L, A> handleErrorWith(fa: EitherTOf<F, L, A>, f: (L) -> EitherTO
     })
   }
 
-fun <F, L, R> EitherT.Companion.fx(M: MonadThrow<F>, c: suspend MonadThrowSyntax<EitherTPartialOf<F, L>>.() -> R): EitherT<F, L, R> =
-  EitherT.monadThrow<F, L>(M, M).fx.monadThrow(c).fix()
+fun <L, F, R> EitherT.Companion.fx(M: MonadThrow<F>, c: suspend MonadThrowSyntax<EitherTPartialOf<L, F>>.() -> R): EitherT<L, F, R> =
+  EitherT.monadThrow<L, F>(M, M).fx.monadThrow(c).fix()
 
 @extension
-interface EitherTEqK<F, L> : EqK<EitherTPartialOf<F, L>> {
+interface EitherTEqK<L, F> : EqK<EitherTPartialOf<L, F>> {
   fun EQKF(): EqK<F>
 
   fun EQL(): Eq<L>
 
-  override fun <R> Kind<EitherTPartialOf<F, L>, R>.eqK(other: Kind<EitherTPartialOf<F, L>, R>, EQ: Eq<R>): Boolean =
+  override fun <R> Kind<EitherTPartialOf<L, F>, R>.eqK(other: Kind<EitherTPartialOf<L, F>, R>, EQ: Eq<R>): Boolean =
     (this.fix() to other.fix()).let {
       EQKF().liftEq(Either.eq(EQL(), EQ)).run {
         it.first.value().eqv(it.second.value())
       }
     }
+}
+
+@extension
+interface EitherTMonadTrans<L> : MonadTrans<Kind<ForEitherT, L>> {
+  override fun <G, A> Kind<G, A>.liftT(MG: Monad<G>): Kind2<Kind<ForEitherT, L>, G, A> =
+    EitherT.liftF(MG, this)
 }


### PR DESCRIPTION
Changed `EitherT<F, A, B>` -> `EitherT<A, F, B>`.

Same reasons as #23 

This branch fails because the `EitherT` from `arrow-test` does not have this change and thus it refuses to compile. We really do need to change how `arrow-test` is distributed somehow @rachelcarmena. I think this is another confimation for the problems noted in https://github.com/arrow-kt/arrow-core/pull/23, `arrow-test`.