### PR TITLE
Fix apEval changes from arrow-core

### DIFF
--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
@@ -71,12 +71,9 @@ interface EitherTApply<F, L> : Apply<EitherTPartialOf<F, L>>, EitherTFunctor<F, 
   override fun <A, B> EitherTOf<F, L, A>.ap(ff: EitherTOf<F, L, (A) -> B>): EitherT<F, L, B> =
     fix().ap(AF(), ff)
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<F, L>, (A) -> B>): Kind<EitherTPartialOf<F, L>, B> =
-    EitherT(
-      AF().run {
-        fix().value().lazyAp { ff().value().map { r -> { l: Either<L, A> -> l.ap(r) } } }
-      }
-    )
+  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.apEval(ff: Eval<Kind<EitherTPartialOf<F, L>, (A) -> B>>): Eval<Kind<EitherTPartialOf<F, L>, B>> =
+    AF().run { value().apEval(ff.map { it.value().map { eitherF -> { eitherA: Either<L, A> -> eitherA.ap(eitherF) } } }) }
+      .map(::EitherT)
 }
 
 @extension
@@ -113,13 +110,6 @@ interface EitherTMonad<F, L> : Monad<EitherTPartialOf<F, L>>, EitherTApplicative
 
   override fun <A, B> tailRecM(a: A, f: (A) -> EitherTOf<F, L, Either<A, B>>): EitherT<F, L, B> =
     EitherT.tailRecM(MF(), a, f)
-
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.lazyAp(ff: () -> Kind<EitherTPartialOf<F, L>, (A) -> B>): Kind<EitherTPartialOf<F, L>, B> =
-    EitherT(
-      AF().run {
-        fix().value().lazyAp { ff().value().map { r -> { l: Either<L, A> -> l.ap(r) } } }
-      }
-    )
 }
 
 @extension

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/optiont.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/optiont.kt
@@ -76,8 +76,9 @@ interface OptionTApplicative<F> : Applicative<OptionTPartialOf<F>>, OptionTFunct
   override fun <A, B> OptionTOf<F, A>.ap(ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
     fix().ap(MF(), ff)
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.lazyAp(ff: () -> Kind<OptionTPartialOf<F>, (A) -> B>): Kind<OptionTPartialOf<F>, B> =
-    fix().flatMap(MF()) { a -> ff().fix().map(MF()) { it(a) } }
+  override fun <A, B> Kind<OptionTPartialOf<F>, A>.apEval(ff: Eval<Kind<OptionTPartialOf<F>, (A) -> B>>): Eval<Kind<OptionTPartialOf<F>, B>> =
+    MF().run { value().apEval(ff.map { it.value().map { optF -> { optA: Option<A> -> optA.ap(optF) } } }) }
+      .map(::OptionT)
 }
 
 @extension
@@ -91,9 +92,6 @@ interface OptionTMonad<F> : Monad<OptionTPartialOf<F>>, OptionTApplicative<F> {
 
   override fun <A, B> OptionTOf<F, A>.ap(ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
     fix().ap(MF(), ff)
-
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.lazyAp(ff: () -> Kind<OptionTPartialOf<F>, (A) -> B>): Kind<OptionTPartialOf<F>, B> =
-    fix().flatMap(MF()) { a -> ff().fix().map(MF()) { it(a) } }
 
   override fun <A, B> tailRecM(a: A, f: (A) -> OptionTOf<F, Either<A, B>>): OptionT<F, B> =
     OptionT.tailRecM(MF(), a, f)
@@ -118,8 +116,6 @@ interface OptionTMonadError<F, E> : MonadError<OptionTPartialOf<F>, E>, OptionTM
 
   override fun ME(): MonadError<F, E>
   override fun MF(): Monad<F> = ME()
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.lazyAp(ff: () -> Kind<OptionTPartialOf<F>, (A) -> B>): Kind<OptionTPartialOf<F>, B> =
-    flatMap { a -> ff().map { it(a) } }
 }
 
 @extension

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/writert.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/writert.kt
@@ -2,6 +2,7 @@ package arrow.mtl.extensions
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.core.extensions.tuple2.eq.eq
 import arrow.core.left
@@ -62,12 +63,10 @@ interface WriterTApplicative<F, W> : Applicative<WriterTPartialOf<F, W>>, Writer
   override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> =
     fix().map(AF()) { f(it) }
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.lazyAp(ff: () -> Kind<WriterTPartialOf<F, W>, (A) -> B>): Kind<WriterTPartialOf<F, W>, B> =
-    WriterT(
-      AF().run {
-        fix().value().lazyAp { ff().fix().value().map { r -> { l: Tuple2<W, A> -> Tuple2(MM().run { l.a + r.a }, r.b(l.b)) } } }
-      }
-    )
+  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.apEval(ff: Eval<Kind<WriterTPartialOf<F, W>, (A) -> B>>): Eval<Kind<WriterTPartialOf<F, W>, B>> =
+    AF().run { fix().value()
+      .apEval(ff.map { it.value().map { (w2, f) -> { (w1, a): Tuple2<W, A> -> MM().run { w1 + w2 } toT f(a) } } }) }
+      .map(::WriterT)
 }
 
 @extension
@@ -91,13 +90,6 @@ interface WriterTMonad<F, W> : Monad<WriterTPartialOf<F, W>>, WriterTApplicative
 
   override fun <A, B> WriterTOf<F, W, A>.ap(ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
     fix().ap(MF(), MM(), ff)
-
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.lazyAp(ff: () -> Kind<WriterTPartialOf<F, W>, (A) -> B>): Kind<WriterTPartialOf<F, W>, B> =
-    WriterT(
-      AF().run {
-        fix().value().lazyAp { ff().fix().value().map { r -> { l: Tuple2<W, A> -> Tuple2(MM().run { l.a + r.a }, r.b(l.b)) } } }
-      }
-    )
 }
 
 @extension


### PR DESCRIPTION
Last of the changes to finally bring `apEval` to all of arrow