### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/arrow-docs/docs/generic/product/README.md
+++ b/arrow-docs/docs/generic/product/README.md
@@ -91,7 +91,7 @@ hListOf(1000, 900).toAccount()
 
 `@product` allows us map independent values in the context of any `Applicative` capable data type straight to the data class inside the data type context
 
-In the examples below we can observe how 2 different `Int` properties are returned inside a type constructor such as `Option`, `Try`, `IO` etc... and the automatically mapped to the shape of our `Account` data class removing all boilerplate from extracting the values from their context and returning an `Account` value in the same context.
+In the examples below we can observe how 2 different `Int` properties are returned inside a type constructor such as `Option`, `IO` etc... and the automatically mapped to the shape of our `Account` data class removing all boilerplate from extracting the values from their context and returning an `Account` value in the same context.
 
 ```kotlin:ank
 import arrow.core.extensions.option.applicative.applicative
@@ -110,26 +110,6 @@ val maybeAvailable: Option<Int> = None
 
 Option.applicative().run {  
   mapToAccount(maybeBalance, maybeAvailable)
-}
-```
-
-```kotlin:ank
-import arrow.core.extensions.`try`.applicative.applicative
-
-val tryBalance: Try<Int> = Try { 1000 }
-val tryAvailable: Try<Int> = Try { 900 }
-
-Try.applicative().run {
-  mapToAccount(tryBalance, tryAvailable)
-}
-```
-
-```kotlin:ank
-val tryBalance: Try<Int> = Try { 1000 }
-val tryAvailable: Try<Int> = Try { throw RuntimeException("BOOM") }
-
-Try.applicative().run {
-  mapToAccount(tryBalance, tryAvailable)
 }
 ```
 


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.