### PR TITLE
Change EitherT MonadError instance

### DIFF
--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
@@ -33,8 +33,8 @@ import arrow.mtl.EitherTPartialOf
 import arrow.mtl.extensions.EitherTMonad
 import arrow.mtl.extensions.EitherTMonadThrow
 import arrow.mtl.value
-import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Monad
+import arrow.typeclasses.MonadThrow
 import arrow.undocumented
 import kotlin.coroutines.CoroutineContext
 
@@ -43,10 +43,7 @@ import kotlin.coroutines.CoroutineContext
 interface EitherTBracket<L, F> : Bracket<EitherTPartialOf<L, F>, Throwable>, EitherTMonadThrow<L, F> {
 
   fun MDF(): MonadDefer<F>
-
-  override fun MF(): Monad<F> = MDF()
-
-  override fun AE(): ApplicativeError<F, Throwable> = MDF()
+  override fun MT(): MonadThrow<F> = MDF()
 
   override fun <A, B> EitherTOf<L, F, A>.bracketCase(
     release: (A, ExitCase<Throwable>) -> EitherTOf<L, F, Unit>,

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/EitherTTest.kt
@@ -28,19 +28,22 @@ import arrow.fx.mtl.concurrent
 import arrow.fx.mtl.timer
 import arrow.mtl.extensions.eithert.alternative.alternative
 import arrow.mtl.extensions.eithert.applicative.applicative
+import arrow.mtl.extensions.eithert.apply.apply
 import arrow.mtl.extensions.eithert.divisible.divisible
 import arrow.mtl.extensions.eithert.eqK.eqK
 import arrow.mtl.extensions.eithert.functor.functor
 import arrow.mtl.extensions.eithert.monad.monad
-import arrow.mtl.extensions.eithert.semigroupK.semigroupK
+import arrow.mtl.extensions.eithert.monadError.monadError
 import arrow.mtl.extensions.eithert.traverse.traverse
 import arrow.test.UnitSpec
 import arrow.test.generators.genK
+import arrow.test.generators.throwable
 import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.DivisibleLaws
-import arrow.test.laws.SemigroupKLaws
+import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.TraverseLaws
+import arrow.test.laws.throwableEq
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
@@ -80,12 +83,16 @@ class EitherTTest : UnitSpec() {
 
       TraverseLaws.laws(EitherT.traverse<Int, ForId>(Id.traverse()),
         EitherT.genK(Id.genK(), Gen.int()),
-        idEQK),
-
-      SemigroupKLaws.laws(
-        EitherT.semigroupK<Int, ForId>(Id.monad()),
-        EitherT.genK(Id.genK(), Gen.int()),
         idEQK
+      ),
+
+      MonadErrorLaws.laws<EitherTPartialOf<Throwable, ForId>>(
+        EitherT.monadError(Id.monad()),
+        EitherT.functor(Id.monad()),
+        EitherT.apply(Id.monad()),
+        EitherT.monad(Id.monad()),
+        EitherT.genK(Id.genK(), Gen.throwable()),
+        EitherT.eqK(Id.eqK(), throwableEq())
       )
     )
 

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/eithert.kt
@@ -5,7 +5,6 @@ import arrow.Kind2
 import arrow.core.Either
 import arrow.core.EitherPartialOf
 import arrow.core.Eval
-import arrow.core.Left
 import arrow.core.Tuple2
 import arrow.core.ap
 import arrow.core.extensions.either.eq.eq
@@ -117,39 +116,39 @@ interface EitherTMonad<L, F> : Monad<EitherTPartialOf<L, F>>, EitherTApplicative
 
 @extension
 @undocumented
-interface EitherTApplicativeError<L, F, E> : ApplicativeError<EitherTPartialOf<L, F>, E>, EitherTApplicative<L, F> {
+interface EitherTApplicativeError<L, F> : ApplicativeError<EitherTPartialOf<L, F>, L>, EitherTApplicative<L, F> {
 
-  fun AE(): ApplicativeError<F, E>
+  fun MF(): Monad<F>
+  override fun AF(): Applicative<F> = MF()
 
-  override fun AF(): Applicative<F> = AE()
+  override fun <A> raiseError(e: L): Kind<EitherTPartialOf<L, F>, A> = EitherT.left(AF(), e)
 
-  override fun <A> raiseError(e: E): EitherT<L, F, A> =
-    EitherT.liftF(AE(), AE().raiseError(e))
-
-  override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (E) -> EitherTOf<L, F, A>): EitherT<L, F, A> = AE().run {
-    EitherT(value().handleErrorWith { l -> f(l).value() })
-  }
+  override fun <A> Kind<EitherTPartialOf<L, F>, A>.handleErrorWith(f: (L) -> Kind<EitherTPartialOf<L, F>, A>): Kind<EitherTPartialOf<L, F>, A> =
+    MF().run {
+      value().flatMap {
+        it.fold({ f(it).value() }, { AF().just(it.right()) })
+      }.let(::EitherT)
+    }
 }
 
 @extension
 @undocumented
-interface EitherTMonadError<L, F, E> : MonadError<EitherTPartialOf<L, F>, E>, EitherTApplicativeError<L, F, E>, EitherTMonad<L, F> {
+interface EitherTMonadError<L, F> : MonadError<EitherTPartialOf<L, F>, L>, EitherTApplicativeError<L, F>, EitherTMonad<L, F> {
   override fun MF(): Monad<F>
-  override fun AE(): ApplicativeError<F, E>
   override fun AF(): Applicative<F> = MF()
 }
 
-fun <L, F, E> EitherT.Companion.monadError(ME: MonadError<F, E>): MonadError<EitherTPartialOf<L, F>, E> =
-  object : EitherTMonadError<L, F, E> {
-    override fun MF(): Monad<F> = ME
-    override fun AE(): ApplicativeError<F, E> = ME
-  }
-
 @extension
 @undocumented
-interface EitherTMonadThrow<L, F> : MonadThrow<EitherTPartialOf<L, F>>, EitherTMonadError<L, F, Throwable> {
-  override fun MF(): Monad<F>
-  override fun AE(): ApplicativeError<F, Throwable>
+interface EitherTMonadThrow<L, F> : MonadThrow<EitherTPartialOf<L, F>>, EitherTMonad<L, F> {
+
+  fun MT(): MonadThrow<F>
+  override fun MF(): Monad<F> = MT()
+
+  override fun <A> Kind<EitherTPartialOf<L, F>, A>.handleErrorWith(f: (Throwable) -> Kind<EitherTPartialOf<L, F>, A>): Kind<EitherTPartialOf<L, F>, A> =
+    MT().run { value().handleErrorWith { f(it).value() }.let(::EitherT) }
+
+  override fun <A> raiseError(e: Throwable): Kind<EitherTPartialOf<L, F>, A> = EitherT.liftF(MT(), MT().raiseError(e))
 }
 
 @extension
@@ -297,41 +296,8 @@ fun <A, F, B, G, C> EitherTOf<A, F, B>.traverse(FF: Traverse<F>, GA: Applicative
 fun <A, G, F, B> EitherTOf<A, F, Kind<G, B>>.sequence(FF: Traverse<F>, GA: Applicative<G>): Kind<G, EitherT<A, F, B>> =
   traverse(FF, GA, ::identity)
 
-fun <L, F> EitherT.Companion.applicativeError(MF: Monad<F>): ApplicativeError<EitherTPartialOf<L, F>, L> =
-  object : ApplicativeError<EitherTPartialOf<L, F>, L>, EitherTApplicative<L, F> {
-
-    override fun AF(): Applicative<F> = MF
-
-    override fun <A> raiseError(e: L): EitherTOf<L, F, A> =
-      EitherT(MF.just(Left(e)))
-
-    override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (L) -> EitherTOf<L, F, A>): EitherT<L, F, A> =
-      handleErrorWith(this, f, MF)
-  }
-
-fun <L, F> EitherT.Companion.monadError(MF: Monad<F>): MonadError<EitherTPartialOf<L, F>, L> =
-  object : MonadError<EitherTPartialOf<L, F>, L>, EitherTMonad<L, F> {
-    override fun MF(): Monad<F> = MF
-
-    override fun <A> raiseError(e: L): EitherTOf<L, F, A> =
-      EitherT(MF.just(Left(e)))
-
-    override fun <A> EitherTOf<L, F, A>.handleErrorWith(f: (L) -> EitherTOf<L, F, A>): EitherT<L, F, A> =
-      handleErrorWith(this, f, MF())
-  }
-
-private fun <L, F, A> handleErrorWith(fa: EitherTOf<L, F, A>, f: (L) -> EitherTOf<L, F, A>, MF: Monad<F>): EitherT<L, F, A> =
-  MF.run {
-    EitherT(fa.value().flatMap {
-      when (it) {
-        is Either.Left -> f(it.a).value()
-        is Either.Right -> just(it)
-      }
-    })
-  }
-
 fun <L, F, R> EitherT.Companion.fx(M: MonadThrow<F>, c: suspend MonadThrowSyntax<EitherTPartialOf<L, F>>.() -> R): EitherT<L, F, R> =
-  EitherT.monadThrow<L, F>(M, M).fx.monadThrow(c).fix()
+  EitherT.monadThrow<L, F>(M).fx.monadThrow(c).fix()
 
 @extension
 interface EitherTEqK<L, F> : EqK<EitherTPartialOf<L, F>> {


### PR DESCRIPTION
Fixes #47. I changed only the `ApplicativeError` and `MonadError` instance, the `Bracket` and `MonadThrow` instances are kept as lift throughs because I think those are more useful in that case. In the case of `Bracket` this may be a bit weird, but since it is mainly used for resource safety together with an `IO` it might be best to leave it to the `IO` which can also fail.

Which means the following patter would be a bad thing:
`aquire().handleErrorWith { e.left() }.let(::EitherT).bracket(...)` because the release is never run as we assume aquire to have succeed. Not sure how we should deal with that...