### PR TITLE
LogicT datatype

### DIFF
--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/LogicT.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/LogicT.kt
@@ -1,0 +1,17 @@
+package arrow.fx.mtl
+
+import arrow.Kind
+import arrow.extension
+import arrow.fx.IO
+import arrow.fx.typeclasses.MonadIO
+import arrow.mtl.LogicT
+import arrow.mtl.LogicTPartialOf
+import arrow.mtl.extensions.LogicTMonad
+
+@extension
+interface LogicTMonadIO<M> : MonadIO<LogicTPartialOf<M>>, LogicTMonad<M> {
+  fun MIO(): MonadIO<M>
+
+  override fun <A> IO<A>.liftIO(): Kind<LogicTPartialOf<M>, A> =
+    LogicT.lift(MIO(), MIO().run { liftIO() })
+}

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/Logic.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/Logic.kt
@@ -1,0 +1,24 @@
+package arrow.mtl
+
+import arrow.core.Eval
+import arrow.core.ForId
+import arrow.core.Id
+import arrow.core.Option
+import arrow.core.extensions.id.monad.monad
+import arrow.core.value
+
+typealias Logic<A> = LogicT<ForId, A>
+
+typealias ForLogic = LogicTPartialOf<ForId>
+
+fun <A, R> Logic<A>.runLogic(f: (A, R) -> R, empty: R): R =
+  runLogicT({ a, mxsEval -> mxsEval.map { Id(f(a, it.value())) } }, Eval.now(Id.just(empty))).value()
+
+fun <A> Logic<A>.observe(): Option<A> = observeT(Id.monad()).value()
+
+fun <A> Logic<A>.observeAll(): List<A> = observeAllT(Id.monad()).value()
+
+// If observeAllT is stacksafe and lazy enough this will be faster than observeManyT
+// This only works if the monad itself is lazy and in kotlin Id is not.
+// fun <A> Logic<A>.observeMany(n: Int): Sequence<A> = observeAll().take(n)
+fun <A> Logic<A>.observeMany(n: Int): List<A> = observeManyT(Id.monad(), n).value()

--- a/arrow-mtl-data/src/main/kotlin/arrow/mtl/LogicT.kt
+++ b/arrow-mtl-data/src/main/kotlin/arrow/mtl/LogicT.kt
@@ -1,0 +1,114 @@
+package arrow.mtl
+
+import arrow.Kind
+import arrow.core.AndThen
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.core.Tuple2
+import arrow.core.none
+import arrow.core.some
+import arrow.core.toT
+import arrow.higherkind
+import arrow.typeclasses.Monad
+
+typealias SuccessFn<M, A, R> = (Tuple2<A, Eval<Kind<M, R>>>) -> Eval<Kind<M, R>>
+
+// Why does this not work? Well because the empty part is fully strict.
+// Solution: Wrap Kind<M, Any?> in Eval. Maybe this also adds enough trampolining to get rid of AndThen...
+@higherkind
+class LogicT<M, A>(
+  internal val unLogicT: AndThen<Tuple2<SuccessFn<M, A, Any?>, Eval<Kind<M, Any?>>>, Eval<Kind<M, Any?>>>
+): LogicTOf<M, A> {
+
+  fun <B> map(f: (A) -> B): LogicT<M, B> =
+    LogicT(unLogicT.compose { (fn, xs) ->
+      AndThen(fn).compose<Tuple2<A, Eval<Kind<M, Any?>>>> { (a, e) -> f(a) toT e } toT xs
+    })
+
+  fun <B> flatMap(f: (A) -> LogicT<M, B>): LogicT<M, B> =
+    LogicT(unLogicT.compose { (fn, xs) ->
+      AndThen.id<Tuple2<A, Eval<Kind<M, Any?>>>>().flatMap { (a, _) ->
+        f(a).unLogicT.compose<Tuple2<A, Eval<Kind<M, Any?>>>> { (_, e) -> fn toT e }
+      } toT xs
+    })
+
+  fun orElse(other: LogicT<M, A>): LogicT<M, A> =
+    LogicT(AndThen.id<Tuple2<SuccessFn<M, A, Any?>, Eval<Kind<M, Any?>>>>().flatMap { (fn, _) ->
+      unLogicT.composeF(other.unLogicT.andThen { fn toT it })
+    })
+
+  // let the unsafe casts begin
+  fun <R> runLogicT(f: (A, Eval<Kind<M, R>>) -> Eval<Kind<M, R>>, empty: Eval<Kind<M, R>>): Kind<M, R> =
+    unLogicT((AndThen<Tuple2<A, Eval<Kind<M, R>>>, Eval<Kind<M, R>>> {
+      f(it.a, it.b)
+    } toT empty) as Tuple2<SuccessFn<M, A, Any?>, Eval<Kind<M, Any?>>>).value() as Kind<M, R>
+
+  fun observeT(MM: Monad<M>): Kind<M, Option<A>> =
+    runLogicT({ a, _ -> Eval.now(MM.just(a.some())) }, Eval.now(MM.just(none())))
+
+  // Uses List to avoid stackoverflows on sequence. Since we don't have any lazy monads anyway there is no point using
+  //  a lazy structure because all effects will be evaluated together with all values anyway.
+  fun observeAllT(MM: Monad<M>): Kind<M, List<A>> =
+    runLogicT({ a, mxsEval ->
+      mxsEval.map { MM.run { it.map { listOf(a) + it } } }
+    }, Eval.now(MM.just(emptyList())))
+
+  fun observeManyT(MM: Monad<M>, n: Int): Kind<M, List<A>> = when {
+    n <= 0 -> MM.just(emptyList())
+    n == 1 -> runLogicT({ a, _ -> Eval.now(MM.just(listOf(a))) }, Eval.now(MM.just(emptyList())))
+    else -> splitM(MM).runLogicT({ splits, _ ->
+      splits.fold({
+        Eval.now(MM.just(emptyList()))
+      }, { (rem, a) ->
+        Eval.now(MM.run { rem.observeManyT(MM, n - 1).map { listOf(a) + it } })
+      })
+    }, Eval.now(MM.just(emptyList())))
+  }
+
+  fun splitM(MM: Monad<M>): LogicT<M, Option<Tuple2<LogicT<M, A>, A>>> =
+    lift(MM, runLogicT({ a, mxsEval ->
+      Eval.now(MM.just((liftEval(MM, mxsEval).flatMap { reflect(it) } toT a).some()))
+    }, Eval.now(MM.just(none()))))
+
+  fun once(): LogicT<M, A> = LogicT(unLogicT.compose { (fn, xs) ->
+    AndThen(fn).compose<Tuple2<A, Eval<Kind<M, Any?>>>> { (a, _) -> a toT xs } toT xs
+  })
+
+  fun voidIfValue(): LogicT<M, Unit> =
+    LogicT(AndThen.id<Tuple2<SuccessFn<M, Unit, Any?>, Eval<Kind<M, Any?>>>>().flatMap { (fn, xs) ->
+      // "run" fn in a stacksafe way to obtain Kind<M, Unit>
+      AndThen(fn).compose<Tuple2<SuccessFn<M, Unit, Any?>, Eval<Kind<M, Any?>>>> { Unit toT xs }.flatMap { ma ->
+        // new choice function that always goes xs and feed in ma
+        unLogicT.compose<Tuple2<SuccessFn<M, Unit, Any?>, Eval<Kind<M, Any?>>>> { (_, _) ->
+          AndThen<Tuple2<A, Eval<Kind<M, Any?>>>, Eval<Kind<M, Any?>>> { xs } toT ma
+        }
+      }
+    })
+
+  companion object {
+    fun <M, A> empty(): LogicT<M, A> = LogicT(AndThen { (_, xs) -> xs })
+
+    fun <M, A> just(a: A): LogicT<M, A> = LogicT(AndThen { (fn, xs) -> Eval.later {}.flatMap { fn(a toT xs) } })
+
+    // lifting is only stacksafe through stacksafe monads
+    fun <M, A> lift(MM: Monad<M>, fa: Kind<M, A>): LogicT<M, A> = LogicT(AndThen { (fn, xs) ->
+      MM.run { Eval.later { fa.flatMap { fn(it toT xs).value() } } }
+    })
+
+    fun <M, A> liftEval(MM: Monad<M>, faEval: Eval<Kind<M, A>>): LogicT<M, A> = LogicT(AndThen { (fn, xs) ->
+      MM.run { faEval.map { it.flatMap { fn(it toT xs).value() } } }
+    })
+  }
+}
+
+fun <M, A, B> LogicTOf<M, A>.ap(ff: LogicTOf<M, (A) -> B>): LogicT<M, B> =
+  LogicT(fix().unLogicT.compose { (fn, xs) ->
+    AndThen.id<Tuple2<A, Eval<Kind<M, Any?>>>>().flatMap { (a, _) ->
+      ff.fix().unLogicT.compose<Tuple2<A, Eval<Kind<M, Any?>>>> { (_, e) ->
+        AndThen(fn).compose<Tuple2<(A) -> B, Eval<Kind<M, Any?>>>> { (f, e1) -> f(a) toT e1 } toT e
+      }
+    } toT xs
+  })
+
+fun <M, A> reflect(opt: Option<Tuple2<LogicT<M, A>, A>>): LogicT<M, A> =
+  opt.fold({ LogicT.empty() }, { (rem, a) -> LogicT.just<M, A>(a).orElse(rem) })

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/LogicTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/LogicTTest.kt
@@ -1,0 +1,155 @@
+package arrow.mtl
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.ForEval
+import arrow.core.ForId
+import arrow.core.Id
+import arrow.core.SequenceK
+import arrow.core.extensions.eval.monad.monad
+import arrow.core.extensions.id.monad.monad
+import arrow.core.extensions.sequencek.foldable.foldable
+import arrow.core.extensions.sequencek.monadLogic.monadLogic
+import arrow.core.k
+import arrow.core.value
+import arrow.fx.extensions.io.monad.monad
+import arrow.mtl.extensions.logict.monadLogic.monadLogic
+import arrow.syntax.collections.tail
+import arrow.typeclasses.MonadLogic
+import arrow.typeclasses.altFromList
+import arrow.typeclasses.altSum
+
+fun main() {
+  fun <A> LogicT<ForId, A>.printList() = observeAllT(Id.monad()).value().also(::println)
+  fun <A> LogicT<ForId, A>.printList(n: Int) = observeManyT(Id.monad(), n).value().also(::println)
+
+  LogicT.monadLogic(Id.monad()).run {
+    val t1 = zeroM<Int>()
+    val t2 = just(10).plusM(just(20)).plusM(just(30))
+    val t3 = listOf(10, 20, 30).altFromList(this)
+
+    fun <F> MonadLogic<F>.odds(): Kind<F, Int> = just(1)
+      // unit().flatMap makes the tail lazy so we don't stackoverflow on construction
+      .plusM(unit().flatMap { odds().map { 2 + it } })
+
+    odds().fix().observeT(Id.monad()).value().also(::println)
+    odds().fix().printList(500)
+
+    // diverges because of unfair interleaving with plusM
+    /*
+    fx.monad {
+      val x = odds().plusM(t3).bind()
+      if (x.rem(2) == 0)
+        x
+      else zeroM<Int>().bind()
+    }.fix().take(1).printList()
+     */
+    // does not diverge because interleave is fair
+    fx.monad {
+      val x = odds().interleave(t3).bind()
+      if (x.rem(2) == 0)
+        x
+      else zeroM<Int>().bind()
+    }.fix().printList(1)
+
+    fun <F> MonadLogic<F>.oddsPlus(n: Int): Kind<F, Int> = odds().map { it + n }
+
+    // diverges because flatMap is unfair
+    /*
+    fx.monad {
+      val x = (just(0).plusM(just(1))).flatMap { oddsPlus(it) }.bind()
+      if (x.rem(2) == 0)
+        x
+      else zeroM<Int>().bind()
+    }.fix().printList(1)
+     */
+
+    // does not diverge because unweave is fair
+    fx.monad {
+      val x = (just(0).plusM(just(1))).unweave { oddsPlus(it) }.bind()
+      if (x.rem(2) == 0)
+        x
+      else zeroM<Int>().bind()
+    }.fix().printList(5)
+
+    fun <F> MonadLogic<F>.iota(n: Int): Kind<F, Int> =
+      (1..n).asSequence().k().map { just(it) }.altSum(this, SequenceK.foldable())
+
+    // Find all non-prime odd numbers
+    fx.monad {
+      val n = odds().bind()
+      guard(n > 1).bind()
+      val d = iota(n - 1).bind()
+      guard(d > 1 && n.rem(d) == 0).bind()
+      n
+    }.fix().printList(10)
+
+    // Finding all prime odd numbers is a bit weirder unless we use the inbuilt ifThen for convenience
+    fx.monad {
+      val n = odds().bind()
+      guard(n > 1).bind()
+
+      iota(n - 1).flatMap { d -> guard(d > 1 && n.rem(d) == 0) }
+        .ifThen(just(n)) { zeroM() }
+        .bind()
+    }.fix().printList(10)
+
+    // Bogosort to show how once works
+    fun <F, A> MonadLogic<F>.insert(l: List<A>, a: A): Kind<F, List<A>> =
+      if (l.isEmpty()) just(listOf(a))
+      else just(listOf(a) + l).plusM(unit().flatMap {
+        insert(l.tail(), a).map { listOf(l.first()) + it }
+      })
+
+    fun <F, A> MonadLogic<F>.permute(l: List<A>): Kind<F, List<A>> =
+      if (l.isEmpty()) just(emptyList<A>())
+      else fx.monad {
+        val p = permute(l.tail()).bind()
+        insert(p, l.first()).bind()
+      }
+
+    fun <F> MonadLogic<F>.bogosort(l: List<Int>): Kind<F, List<Int>> =
+      permute(l).flatMap { xs -> if (xs.sorted() == xs) just(xs) else zeroM() }
+
+    // two solutions because of the two equal elements => unnecessary work
+    bogosort(listOf(5, 0, 3, 4, 0, 1)).fix().printList()
+
+    fun <F> MonadLogic<F>.bogosort2(l: List<Int>): Kind<F, List<Int>> =
+      bogosort(l).once()
+
+    // just one solution because once discarded all others. Will avoid extra work if the result in `F` is lazy
+    bogosort2(listOf(5, 0, 3, 4, 0, 1)).fix().printList()
+
+    // this also allows a faster version of our prime finder by using once to prune the condition
+    fx.monad {
+      val n = odds().bind()
+      guard(n > 1).bind()
+
+      iota(n - 1).flatMap { d -> guard(d > 1 && n.rem(d) == 0) }
+        .once() // we only need one element that passes, because that already means n is not prime
+        .ifThen(just(n)) { zeroM() }
+        .bind()
+    }.fix().printList(10)
+
+    // this is a very common pattern which is why there is a shortcut
+    fx.monad {
+      val n = odds().bind()
+      guard(n > 1).bind()
+
+      iota(n - 1).flatMap { d -> guard(d > 1 && n.rem(d) == 0) }
+        .voidIfValue() // shortcut for once().ifThen(unit()) { zeroM() }
+        // currently bugged and diverges: https://github.com/arrow-kt/arrow-core/pull/56 fixes that
+        .bind()
+
+      n
+    }.fix().printList(10)
+  }
+}
+
+/*
+class LogicTTest : UnitSpec() {
+  init {
+
+  }
+}
+*/

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/LogicT.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/LogicT.kt
@@ -1,0 +1,149 @@
+package arrow.mtl.extensions
+
+import arrow.Kind
+import arrow.Kind2
+import arrow.core.AndThen
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.core.Tuple2
+import arrow.core.andThen
+import arrow.core.toT
+import arrow.extension
+import arrow.mtl.ForLogicT
+import arrow.mtl.LogicT
+import arrow.mtl.LogicTPartialOf
+import arrow.mtl.fix
+import arrow.mtl.typeclasses.MonadReader
+import arrow.mtl.typeclasses.MonadState
+import arrow.mtl.typeclasses.MonadTrans
+import arrow.typeclasses.Alternative
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.ApplicativeError
+import arrow.typeclasses.Functor
+import arrow.typeclasses.Monad
+import arrow.typeclasses.MonadError
+import arrow.typeclasses.MonadLogic
+import arrow.typeclasses.MonadPlus
+import arrow.typeclasses.MonoidK
+import arrow.typeclasses.SemigroupK
+import arrow.mtl.ap as logicTAp
+
+@extension
+interface LogicTFunctor<M> : Functor<LogicTPartialOf<M>> {
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.map(f: (A) -> B): Kind<LogicTPartialOf<M>, B> =
+    fix().map(f)
+}
+
+@extension
+interface LogicTApplicative<M> : Applicative<LogicTPartialOf<M>>, LogicTFunctor<M> {
+  override fun <A> just(a: A): Kind<LogicTPartialOf<M>, A> = LogicT.just(a)
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.ap(ff: Kind<LogicTPartialOf<M>, (A) -> B>): Kind<LogicTPartialOf<M>, B> =
+    logicTAp(ff)
+
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.map(f: (A) -> B): Kind<LogicTPartialOf<M>, B> =
+    fix().map(f)
+}
+
+@extension
+interface LogicTMonad<M> : Monad<LogicTPartialOf<M>>, LogicTApplicative<M> {
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.flatMap(f: (A) -> Kind<LogicTPartialOf<M>, B>): Kind<LogicTPartialOf<M>, B> =
+    fix().flatMap(f.andThen { it.fix() })
+
+  override fun <A, B> tailRecM(a: A, f: (A) -> Kind<LogicTPartialOf<M>, Either<A, B>>): Kind<LogicTPartialOf<M>, B> =
+    f(a).flatMap { it.fold({ tailRecM(it, f) }, { LogicT.just(it) }) }
+
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.ap(ff: Kind<LogicTPartialOf<M>, (A) -> B>): Kind<LogicTPartialOf<M>, B> =
+    logicTAp(ff)
+
+  override fun <A, B> Kind<LogicTPartialOf<M>, A>.map(f: (A) -> B): Kind<LogicTPartialOf<M>, B> =
+    fix().map(f)
+}
+
+@extension
+interface LogicTSemigroupK<M> : SemigroupK<LogicTPartialOf<M>> {
+  override fun <A> Kind<LogicTPartialOf<M>, A>.combineK(y: Kind<LogicTPartialOf<M>, A>): Kind<LogicTPartialOf<M>, A> =
+    fix().orElse(y.fix())
+}
+
+@extension
+interface LogicTMonoidK<M> : MonoidK<LogicTPartialOf<M>>, LogicTSemigroupK<M> {
+  override fun <A> empty(): Kind<LogicTPartialOf<M>, A> = LogicT.empty()
+}
+
+@extension
+interface LogicTAlternative<M> : Alternative<LogicTPartialOf<M>>, LogicTApplicative<M> {
+  override fun <A> Kind<LogicTPartialOf<M>, A>.orElse(b: Kind<LogicTPartialOf<M>, A>): Kind<LogicTPartialOf<M>, A> =
+    fix().orElse(b.fix())
+
+  override fun <A> empty(): Kind<LogicTPartialOf<M>, A> = LogicT.empty()
+}
+
+@extension
+interface LogicTMonadPlus<M> : MonadPlus<LogicTPartialOf<M>>, LogicTAlternative<M>, LogicTMonad<M>
+
+@extension
+interface LogicTMonadLogic<M> : MonadLogic<LogicTPartialOf<M>>, LogicTMonadPlus<M> {
+  fun MM(): Monad<M>
+
+  override fun <A> Kind<LogicTPartialOf<M>, A>.splitM(): Kind<LogicTPartialOf<M>, Option<Tuple2<Kind<LogicTPartialOf<M>, A>, A>>> =
+    fix().splitM(MM())
+
+  override fun <A> Kind<LogicTPartialOf<M>, A>.once(): Kind<LogicTPartialOf<M>, A> =
+    fix().once()
+
+  override fun <A> Kind<LogicTPartialOf<M>, A>.voidIfValue(): Kind<LogicTPartialOf<M>, Unit> =
+    fix().voidIfValue()
+}
+
+@extension
+interface LogicTMonadTrans : MonadTrans<ForLogicT> {
+  override fun <G, A> Kind<G, A>.liftT(MG: Monad<G>): Kind2<ForLogicT, G, A> =
+    LogicT.lift(MG, this)
+}
+
+/*
+@extension
+interface LogicTMonadReader<M, D> : MonadReader<LogicTPartialOf<M>, D>, LogicTMonad<M> {
+  fun MR(): MonadReader<M, D>
+  override fun ask(): Kind<LogicTPartialOf<M>, D> = LogicT.lift(MR(), MR().ask())
+  override fun <A> Kind<LogicTPartialOf<M>, A>.local(f: (D) -> D): Kind<LogicTPartialOf<M>, A> =
+    LogicT(AndThen { (fn, mxs) ->
+      Eval.later {
+        MR().run {
+          ask().flatMap { d ->
+            fix().let { l ->
+              l.runLogicT({ a, mxs2Eval ->
+                fn(a toT mxs2Eval).map { it.local { d } }
+              }, mxs.map { it.local { d } })
+            }.local(f)
+          }
+        }
+      }.
+    })
+}
+
+@extension
+interface LogicTMonadState<M, S> : MonadState<LogicTPartialOf<M>, S>, LogicTMonad<M> {
+  fun MS(): MonadState<M, S>
+  override fun get(): Kind<LogicTPartialOf<M>, S> = LogicT.lift(MS(), MS().get())
+  override fun set(s: S): Kind<LogicTPartialOf<M>, Unit> = LogicT.lift(MS(), MS().set(s))
+}
+
+@extension
+interface LogicTApplicativeError<M, E> : ApplicativeError<LogicTPartialOf<M>, E>, LogicTApplicative<M> {
+  fun ME(): MonadError<M, E>
+
+  override fun <A> raiseError(e: E): Kind<LogicTPartialOf<M>, A> = LogicT.lift(ME(), ME().raiseError(e))
+
+  override fun <A> Kind<LogicTPartialOf<M>, A>.handleErrorWith(f: (E) -> Kind<LogicTPartialOf<M>, A>): Kind<LogicTPartialOf<M>, A> =
+    LogicT(AndThen { (fn, mxs) ->
+      ME().run {
+        fun Kind<M, Any?>.handle(): Kind<M, Any?> =
+          handleErrorWith { e -> f(e).fix().runLogicT({ a, mxs2 -> fn(a toT mxs2) }, mxs) }
+
+        fix().runLogicT({ a, mxs2 -> fn(a toT mxs2.handle()) }, mxs).handle()
+      }
+    })
+}
+*/


### PR DESCRIPTION
Implements the transformer `LogicT` which adds backtracking functionality to the underlying monad. The list/sequence monads (or better their transformer variants, which we for good reason don't have) are similar, but `LogicT` is a better encoding that does not violate any laws regardless of what monad instance is used as the base.

This is a good carrier instance for `MonadLogic` because it allows effects together with backtracking which `List` and `Sequence` can't.

For those interested: `ListT` is only a lawful monad if the underlying monad is commutative which for the most interesting base monad `IO` is not the case.

I will add this as documentation later, but for now:
`LogicT` is a wrapper around `forall r . (a -> m r -> m r) -> m r -> m r`. The first parameter `(a -> m r -> m r)` is best understood as the success part of our computation. Implementations are given the first successful result and an action which calculates all remaining results. This means we can choose to only use the first or to collect all. There is also a function that collects n results, however that is much more expensive. The second parameter `m r` is the failure parameter and usually passed to the first as the last option. This encoding makes it quite difficult to have it be stacksafe... 

This has a few problems:
- Because of missing laziness in kotlin this has to extensively use `Eval` to avoid diverging in the success function (if the action to calculate all remaining is strict it diverges...). This means extra care has to be taken around constructors like `just`, `lift` and `splitM`
- In general this is not stacksafe unless `M` is. The reason lies in `splitM` which has to use `lift`/`liftEval` to work. Those methods have to `flatMap` through the supplied action and in there evaluate the `Eval`. 
- All other means of stacksafety come from `AndThen` which is just a giant puzzle. Apart from `just`/`lift`/`liftEval` and `splitM` nothing ever invokes a function or evaluates an eval, so it is stacksafe in all other functions.
- I am also pretty sure that some other stacksafety problems will show up...
- All the wrapping with `AndThen` and `Eval` may mean that this is exceptionally slow. But since we have no comparable instance anyway that probably does not matter...