### PR TITLE
AQL instances for Effects

### DIFF
--- a/arrow-aql/build.gradle
+++ b/arrow-aql/build.gradle
@@ -16,6 +16,7 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     compileOnly "io.arrow-kt:arrow-core:$VERSION_NAME"
+    compileOnly "io.arrow-kt:arrow-fx:$VERSION_NAME", excludeArrow
     compileOnly "io.arrow-kt:arrow-meta:$VERSION_NAME"
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
     kaptTest "io.arrow-kt:arrow-meta:$VERSION_NAME"

--- a/arrow-aql/src/main/kotlin/arrow/aql/RaisableQuery.kt
+++ b/arrow-aql/src/main/kotlin/arrow/aql/RaisableQuery.kt
@@ -1,0 +1,7 @@
+package arrow.aql
+
+data class RaisableQuery<out F, A, out Z>(
+  val select: Selection<A, Z>,
+  val from: Source<F, A>,
+  val predicate: A.() -> Boolean
+)

--- a/arrow-aql/src/main/kotlin/arrow/aql/WhereOr.kt
+++ b/arrow-aql/src/main/kotlin/arrow/aql/WhereOr.kt
@@ -1,0 +1,19 @@
+package arrow.aql
+
+import arrow.typeclasses.MonadError
+
+interface WhereOr<F, E> {
+
+  fun monadError(): MonadError<F, E>
+
+  infix fun <A, Z> Query<F, A, Z>.where(predicate: A.() -> Boolean): RaisableQuery<F, A, Z> =
+    RaisableQuery(select, from, predicate)
+
+  infix fun <A, Z> RaisableQuery<F, A, Z>.orRaise(error: () -> E): Query<F, A, Z> =
+    monadError().run {
+      Query(
+        select,
+        from.ensure(error, predicate)
+      )
+    }
+}

--- a/arrow-aql/src/main/kotlin/arrow/aql/extensions/either.kt
+++ b/arrow-aql/src/main/kotlin/arrow/aql/extensions/either.kt
@@ -1,23 +1,17 @@
 package arrow.aql.extensions
 
-import arrow.aql.Select
-import arrow.aql.From
-import arrow.aql.GroupBy
-import arrow.aql.Count
-import arrow.aql.Sum
-import arrow.aql.OrderBy
-import arrow.aql.Union
-import arrow.aql.Max
-import arrow.aql.Min
+import arrow.aql.*
 import arrow.core.Either
 import arrow.core.EitherPartialOf
 import arrow.core.extensions.either.applicative.applicative
 import arrow.core.extensions.either.foldable.foldable
 import arrow.core.extensions.either.functor.functor
+import arrow.core.extensions.either.monadError.monadError
 import arrow.extension
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
+import arrow.typeclasses.MonadError
 
 @extension interface EitherSelect<L> : Select<EitherPartialOf<L>> {
   override fun functor(): Functor<EitherPartialOf<L>> = Either.functor()
@@ -26,6 +20,11 @@ import arrow.typeclasses.Functor
 @extension
 interface EitherFrom<L> : From<EitherPartialOf<L>> {
   override fun applicative(): Applicative<EitherPartialOf<L>> = Either.applicative()
+}
+
+@extension
+interface EitherWhereOr<L> : WhereOr<EitherPartialOf<L>, L> {
+  override fun monadError(): MonadError<EitherPartialOf<L>, L> = Either.monadError()
 }
 
 @extension

--- a/arrow-aql/src/main/kotlin/arrow/aql/extensions/either.kt
+++ b/arrow-aql/src/main/kotlin/arrow/aql/extensions/either.kt
@@ -1,6 +1,15 @@
 package arrow.aql.extensions
 
-import arrow.aql.*
+import arrow.aql.Select
+import arrow.aql.From
+import arrow.aql.WhereOr
+import arrow.aql.GroupBy
+import arrow.aql.Count
+import arrow.aql.Sum
+import arrow.aql.OrderBy
+import arrow.aql.Union
+import arrow.aql.Max
+import arrow.aql.Min
 import arrow.core.Either
 import arrow.core.EitherPartialOf
 import arrow.core.extensions.either.applicative.applicative

--- a/arrow-aql/src/main/kotlin/arrow/aql/extensions/io.kt
+++ b/arrow-aql/src/main/kotlin/arrow/aql/extensions/io.kt
@@ -1,0 +1,29 @@
+package arrow.aql.extensions
+
+import arrow.aql.From
+import arrow.aql.Select
+import arrow.aql.WhereOr
+import arrow.extension
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.extensions.io.functor.functor
+import arrow.fx.extensions.io.monadError.monadError
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Functor
+import arrow.typeclasses.MonadError
+
+@extension
+interface IOSelect : Select<ForIO> {
+  override fun functor(): Functor<ForIO> = IO.functor()
+}
+
+@extension
+interface IOFrom : From<ForIO> {
+  override fun applicative(): Applicative<ForIO> = IO.applicative()
+}
+
+@extension
+interface IOWhereOr : WhereOr<ForIO, Throwable> {
+  override fun monadError(): MonadError<ForIO, Throwable> = IO.monadError()
+}

--- a/arrow-aql/src/test/kotlin/arrow/aql/tests/AQLTests.kt
+++ b/arrow-aql/src/test/kotlin/arrow/aql/tests/AQLTests.kt
@@ -1,6 +1,11 @@
 package arrow.aql.tests
 
 import arrow.aql.Ord
+import arrow.aql.extensions.either.select.query
+import arrow.aql.extensions.either.select.select
+import arrow.aql.extensions.either.select.value
+import arrow.aql.extensions.either.whereOr.orRaise
+import arrow.aql.extensions.either.whereOr.where
 import arrow.aql.extensions.list.count.count
 import arrow.aql.extensions.list.from.join
 import arrow.aql.extensions.list.groupBy.groupBy
@@ -26,7 +31,9 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.None
 import arrow.core.extensions.order
-import arrow.core.test.UnitSpec
+import arrow.core.left
+import arrow.core.right
+import arrow.test.UnitSpec
 import io.kotlintest.shouldBe
 
 class AQLTests : UnitSpec() {
@@ -85,6 +92,20 @@ class AQLTests : UnitSpec() {
       listOf(john, jane, jack).query {
         selectAll() where { age > 30 } groupBy { age }
       }.value() shouldBe mapOf(32 to listOf(jane, jack))
+    }
+
+    "AQL is able to filter using `whereOr`" {
+      john.right().query {
+        select { name } where { this.name.startsWith("J") } orRaise { "InvalidName" }
+      }.value() shouldBe john.name.right()
+    }
+
+    "AQL is unable to filter using `whereOr`" {
+      val error = "InvalidName"
+
+      john.right().query {
+        select { name } where { this.name.startsWith("a") } orRaise { error }
+      }.value() shouldBe error.left()
     }
 
     "AQL is able to `sum`" {


### PR DESCRIPTION
This PR fix #15.

You can follow the previous conversation [here](https://github.com/arrow-kt/arrow/pull/1332).

Tasks:
- [x] Create `WhereOr` Typeclass;
- [x] Create `EitherWhereOr` instance;
- [x] Add instances for `IO`;
- [ ] Add instances for `FlowableK`;
- [ ] Add instances for `MaybeK`;
- [ ] Add instances for `ObservableK`;
- [ ] Add instances for `SingleK`;
- [ ] Add instances for `ObservableK`;
- [ ] Add instances for `FluxK`;
- [ ] Add instances for `MonoK`;
- [ ] Add tests;
- [ ] Add `WhereOr` to docs;
- [ ] Add effects to docs;