### PR TITLE
Reactivate ConcurrentLaws tests and fix Concurrent instances

### DIFF
--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
@@ -122,8 +122,8 @@ interface EitherTConcurrent<L, F> : Concurrent<EitherTPartialOf<L, F>>, EitherTA
   override fun dispatchers(): Dispatchers<EitherTPartialOf<L, F>> =
     CF().dispatchers() as Dispatchers<EitherTPartialOf<L, F>>
 
-  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<EitherTPartialOf<L, F>>): EitherT<L, F, A> = CF().run {
-    EitherT.liftF(this, cancelable(k.andThen { it.value().void() }))
+  override fun <A> cancellable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<EitherTPartialOf<L, F>>): EitherT<L, F, A> = CF().run {
+    EitherT.liftF(this, cancellable(k.andThen { it.value().void() }))
   }
 
   override fun <A> EitherTOf<L, F, A>.fork(ctx: CoroutineContext): EitherT<L, F, Fiber<EitherTPartialOf<L, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
@@ -9,6 +9,7 @@ import arrow.core.Right
 import arrow.core.Some
 import arrow.core.Tuple2
 import arrow.core.Tuple3
+import arrow.core.andThen
 import arrow.core.flatMap
 import arrow.extension
 import arrow.fx.IO
@@ -122,7 +123,7 @@ interface EitherTConcurrent<L, F> : Concurrent<EitherTPartialOf<L, F>>, EitherTA
     CF().dispatchers() as Dispatchers<EitherTPartialOf<L, F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<EitherTPartialOf<L, F>>): EitherT<L, F, A> = CF().run {
-    EitherT.liftF(this, cancelable { cb -> k(cb).value().map { Unit } })
+    EitherT.liftF(this, cancelable(k.andThen { it.value().void() }))
   }
 
   override fun <A> EitherTOf<L, F, A>.fork(ctx: CoroutineContext): EitherT<L, F, Fiber<EitherTPartialOf<L, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
@@ -5,6 +5,7 @@ import arrow.core.AndThen
 import arrow.core.Either
 import arrow.core.Tuple2
 import arrow.core.Tuple3
+import arrow.core.andThen
 import arrow.extension
 import arrow.fx.IO
 import arrow.fx.RacePair
@@ -122,7 +123,7 @@ interface KleisliConcurrent<D, F> : Concurrent<KleisliPartialOf<D, F>>, KleisliA
     CF().dispatchers() as Dispatchers<KleisliPartialOf<D, F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<KleisliPartialOf<D, F>>): Kleisli<D, F, A> = CF().run {
-    Kleisli { d -> cancelable { cb -> k(cb).run(d).map { Unit } } }
+    Kleisli { d -> cancelable(k.andThen { it.run(d).void() } }
   }
 
   override fun <A> KleisliOf<D, F, A>.fork(ctx: CoroutineContext): Kleisli<D, F, Fiber<KleisliPartialOf<D, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
@@ -123,7 +123,7 @@ interface KleisliConcurrent<D, F> : Concurrent<KleisliPartialOf<D, F>>, KleisliA
     CF().dispatchers() as Dispatchers<KleisliPartialOf<D, F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<KleisliPartialOf<D, F>>): Kleisli<D, F, A> = CF().run {
-    Kleisli { d -> cancelable(k.andThen { it.run(d).void() } }
+    Kleisli { d -> cancelable(k.andThen { it.run(d).void() }) }
   }
 
   override fun <A> KleisliOf<D, F, A>.fork(ctx: CoroutineContext): Kleisli<D, F, Fiber<KleisliPartialOf<D, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/kleisli.kt
@@ -122,8 +122,8 @@ interface KleisliConcurrent<D, F> : Concurrent<KleisliPartialOf<D, F>>, KleisliA
   override fun dispatchers(): Dispatchers<KleisliPartialOf<D, F>> =
     CF().dispatchers() as Dispatchers<KleisliPartialOf<D, F>>
 
-  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<KleisliPartialOf<D, F>>): Kleisli<D, F, A> = CF().run {
-    Kleisli { d -> cancelable(k.andThen { it.run(d).void() }) }
+  override fun <A> cancellable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<KleisliPartialOf<D, F>>): Kleisli<D, F, A> = CF().run {
+    Kleisli { d -> cancellable(k.andThen { it.run(d).void() }) }
   }
 
   override fun <A> KleisliOf<D, F, A>.fork(ctx: CoroutineContext): Kleisli<D, F, Fiber<KleisliPartialOf<D, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
@@ -112,8 +112,8 @@ interface OptionTConcurrent<F> : Concurrent<OptionTPartialOf<F>>, OptionTAsync<F
   override fun dispatchers(): Dispatchers<OptionTPartialOf<F>> =
     CF().dispatchers() as Dispatchers<OptionTPartialOf<F>>
 
-  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<OptionTPartialOf<F>>): OptionT<F, A> = CF().run {
-    OptionT.liftF(this, cancelable(k.andThen { it.value().void() }))
+  override fun <A> cancellable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<OptionTPartialOf<F>>): OptionT<F, A> = CF().run {
+    OptionT.liftF(this, cancellable(k.andThen { it.value().void() }))
   }
 
   override fun <A> OptionTOf<F, A>.fork(ctx: CoroutineContext): OptionT<F, Fiber<OptionTPartialOf<F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
@@ -7,6 +7,7 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.Tuple2
 import arrow.core.Tuple3
+import arrow.core.andThen
 import arrow.extension
 import arrow.fx.IO
 import arrow.fx.RacePair
@@ -112,7 +113,7 @@ interface OptionTConcurrent<F> : Concurrent<OptionTPartialOf<F>>, OptionTAsync<F
     CF().dispatchers() as Dispatchers<OptionTPartialOf<F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<OptionTPartialOf<F>>): OptionT<F, A> = CF().run {
-    OptionT.liftF(this, cancelable { cb -> k(cb).value().map { Unit } })
+    OptionT.liftF(this, cancelable(k.andThen { it.value().void() }))
   }
 
   override fun <A> OptionTOf<F, A>.fork(ctx: CoroutineContext): OptionT<F, Fiber<OptionTPartialOf<F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
@@ -112,7 +112,7 @@ interface WriterTConcurrent<W, F> : Concurrent<WriterTPartialOf<W, F>>, WriterTA
     CF().dispatchers() as Dispatchers<WriterTPartialOf<W, F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<WriterTPartialOf<W, F>>): WriterT<W, F, A> = CF().run {
-    WriterT.liftF(cancelable(k.andThen { it.value().void() })), MM(), this)
+    WriterT.liftF(cancelable(k.andThen { it.value().void() }), MM(), this)
   }
 
   override fun <A> WriterTOf<W, F, A>.fork(ctx: CoroutineContext): WriterT<W, F, Fiber<WriterTPartialOf<W, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
@@ -111,8 +111,8 @@ interface WriterTConcurrent<W, F> : Concurrent<WriterTPartialOf<W, F>>, WriterTA
   override fun dispatchers(): Dispatchers<WriterTPartialOf<W, F>> =
     CF().dispatchers() as Dispatchers<WriterTPartialOf<W, F>>
 
-  override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<WriterTPartialOf<W, F>>): WriterT<W, F, A> = CF().run {
-    WriterT.liftF(cancelable(k.andThen { it.value().void() }), MM(), this)
+  override fun <A> cancellable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<WriterTPartialOf<W, F>>): WriterT<W, F, A> = CF().run {
+    WriterT.liftF(cancellable(k.andThen { it.value().void() }), MM(), this)
   }
 
   override fun <A> WriterTOf<W, F, A>.fork(ctx: CoroutineContext): WriterT<W, F, Fiber<WriterTPartialOf<W, F>, A>> = CF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Tuple2
 import arrow.core.Tuple3
+import arrow.core.andThen
 import arrow.core.internal.AtomicRefW
 import arrow.extension
 import arrow.fx.IO
@@ -111,7 +112,7 @@ interface WriterTConcurrent<W, F> : Concurrent<WriterTPartialOf<W, F>>, WriterTA
     CF().dispatchers() as Dispatchers<WriterTPartialOf<W, F>>
 
   override fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<WriterTPartialOf<W, F>>): WriterT<W, F, A> = CF().run {
-    WriterT.liftF(cancelable { cb -> k(cb).value().unit() }, MM(), this)
+    WriterT.liftF(cancelable(k.andThen { it.value().void() })), MM(), this)
   }
 
   override fun <A> WriterTOf<W, F, A>.fork(ctx: CoroutineContext): WriterT<W, F, Fiber<WriterTPartialOf<W, F>, A>> = CF().run {

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/EitherTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/EitherTTest.kt
@@ -28,7 +28,15 @@ import arrow.core.test.laws.TraverseLaws
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.test.eq.eqK
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.extensions.io.functor.functor
+import arrow.fx.extensions.io.monad.monad
+import arrow.fx.mtl.concurrent
+import arrow.fx.mtl.timer
 import arrow.fx.test.eq.throwableEq
+import arrow.fx.test.generators.genK
+import arrow.fx.test.laws.ConcurrentLaws
 import arrow.mtl.EitherT
 import arrow.mtl.EitherTPartialOf
 import arrow.mtl.ForEitherT
@@ -39,6 +47,7 @@ import arrow.mtl.StateTPartialOf
 import arrow.mtl.WriterT
 import arrow.mtl.WriterTPartialOf
 import arrow.mtl.extensions.eithert.alternative.alternative
+import arrow.mtl.extensions.eithert.applicative.applicative
 import arrow.mtl.extensions.eithert.apply.apply
 import arrow.mtl.extensions.eithert.divisible.divisible
 import arrow.mtl.extensions.eithert.eqK.eqK
@@ -85,15 +94,15 @@ class EitherTTest : UnitSpec() {
         idEQK
       ),
 
-      // ConcurrentLaws.laws<EitherTPartialOf<String, ForIO>>(
-      //   EitherT.concurrent(IO.concurrent()),
-      //   EitherT.timer(IO.concurrent()),
-      //   EitherT.functor(IO.functor()),
-      //   EitherT.applicative(IO.applicative()),
-      //   EitherT.monad(IO.monad()),
-      //   EitherT.genK(IO.genK(), Gen.string()),
-      //   ioEQK
-      // ),
+      ConcurrentLaws.laws<EitherTPartialOf<String, ForIO>>(
+        EitherT.concurrent(IO.concurrent()),
+        EitherT.timer(IO.concurrent()),
+        EitherT.functor(IO.functor()),
+        EitherT.applicative(IO.applicative()),
+        EitherT.monad(IO.monad()),
+        EitherT.genK(IO.genK(), Gen.string()),
+        ioEQK
+      ),
 
       TraverseLaws.laws(EitherT.traverse<Int, ForId>(Id.traverse()),
         EitherT.genK(Id.genK(), Gen.int()),

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/EitherTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/EitherTTest.kt
@@ -98,7 +98,7 @@ class EitherTTest : UnitSpec() {
         EitherT.concurrent(IO.concurrent()),
         EitherT.timer(IO.concurrent()),
         EitherT.functor(IO.functor()),
-        EitherT.applicative(IO.applicative()),
+        EitherT.applicative(IO.monad()),
         EitherT.monad(IO.monad()),
         EitherT.genK(IO.genK(), Gen.string()),
         ioEQK

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/KleisliTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/KleisliTest.kt
@@ -28,6 +28,14 @@ import arrow.core.test.laws.MonadLogicLaws
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.test.eq.eqK
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.extensions.io.functor.functor
+import arrow.fx.extensions.io.monad.monad
+import arrow.fx.mtl.concurrent
+import arrow.fx.mtl.timer
+import arrow.fx.test.generators.genK
+import arrow.fx.test.laws.ConcurrentLaws
 import arrow.mtl.ForKleisli
 import arrow.mtl.Kleisli
 import arrow.mtl.KleisliPartialOf
@@ -36,6 +44,7 @@ import arrow.mtl.StateTPartialOf
 import arrow.mtl.WriterT
 import arrow.mtl.WriterTPartialOf
 import arrow.mtl.extensions.kleisli.alternative.alternative
+import arrow.mtl.extensions.kleisli.applicative.applicative
 import arrow.mtl.extensions.kleisli.divisible.divisible
 import arrow.mtl.extensions.kleisli.monadLogic.monadLogic
 import arrow.mtl.extensions.kleisli.monadReader.monadReader
@@ -49,6 +58,8 @@ import arrow.mtl.test.generators.genK
 import arrow.mtl.test.laws.MonadReaderLaws
 import arrow.mtl.test.laws.MonadStateLaws
 import arrow.mtl.test.laws.MonadWriterLaws
+import arrow.mtl.extensions.kleisli.functor.functor
+import arrow.mtl.extensions.kleisli.monad.monad
 import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
 import io.kotlintest.shouldBe
@@ -68,15 +79,15 @@ class KleisliTest : UnitSpec() {
         Kleisli.genK<Int, ForOption>(Option.genK()),
         optionEQK
       ),
-      // ConcurrentLaws.laws<KleisliPartialOf<Int, ForIO>>(
-      //   Kleisli.concurrent(IO.concurrent()),
-      //   Kleisli.timer(IO.concurrent()),
-      //   Kleisli.functor(IO.functor()),
-      //   Kleisli.applicative(IO.applicative()),
-      //   Kleisli.monad(IO.monad()),
-      //   genK(IO.genK()),
-      //   ioEQK
-      // ),
+      ConcurrentLaws.laws<KleisliPartialOf<Int, ForIO>>(
+        Kleisli.concurrent(IO.concurrent()),
+        Kleisli.timer(IO.concurrent()),
+        Kleisli.functor(IO.functor()),
+        Kleisli.applicative(IO.applicative()),
+        Kleisli.monad(IO.monad()),
+        Kleisli.genK(IO.genK()),
+        ioEQK
+      ),
       DivisibleLaws.laws(
         Kleisli.divisible<Int, ConstPartialOf<Int>>(Const.divisible(Int.monoid())),
         Kleisli.genK<Int, ConstPartialOf<Int>>(Const.genK(Gen.int())),

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/OptionTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/OptionTTest.kt
@@ -30,6 +30,13 @@ import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.TraverseFilterLaws
 import arrow.fx.IO
 import arrow.fx.test.eq.eqK
+import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.extensions.io.functor.functor
+import arrow.fx.extensions.io.monad.monad
+import arrow.fx.mtl.concurrent
+import arrow.fx.mtl.timer
+import arrow.fx.test.generators.genK
+import arrow.fx.test.laws.ConcurrentLaws
 import arrow.mtl.EitherT
 import arrow.mtl.Kleisli
 import arrow.mtl.KleisliPartialOf
@@ -44,6 +51,7 @@ import arrow.mtl.extensions.nested
 import arrow.mtl.extensions.optiont.applicative.applicative
 import arrow.mtl.extensions.optiont.divisible.divisible
 import arrow.mtl.extensions.optiont.eqK.eqK
+import arrow.mtl.extensions.optiont.functor.functor
 import arrow.mtl.extensions.optiont.functorFilter.functorFilter
 import arrow.mtl.extensions.optiont.monad.monad
 import arrow.mtl.extensions.optiont.monadPlus.monadPlus
@@ -81,15 +89,15 @@ class OptionTTest : UnitSpec() {
     val nestedEQK = OptionT.eqK(Id.eqK()).nested(OptionT.eqK(NonEmptyList.eqK()))
 
     testLaws(
-      // ConcurrentLaws.laws(
-      //   OptionT.concurrent(IO.concurrent()),
-      //   OptionT.timer(IO.concurrent()),
-      //   OptionT.functor(IO.functor()),
-      //   OptionT.applicative(IO.monad()),
-      //   OptionT.monad(IO.monad()),
-      //   OptionT.genK(IO.genK()),
-      //   ioEQK
-      // ),
+      ConcurrentLaws.laws(
+        OptionT.concurrent(IO.concurrent()),
+        OptionT.timer(IO.concurrent()),
+        OptionT.functor(IO.functor()),
+        OptionT.applicative(IO.monad()),
+        OptionT.monad(IO.monad()),
+        OptionT.genK(IO.genK()),
+        ioEQK
+      ),
 
       SemigroupKLaws.laws(
         OptionT.semigroupK(Option.monad()),

--- a/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/WriterTTest.kt
+++ b/arrow-mtl-data/src/test/kotlin/arrow/mtl/test/WriterTTest.kt
@@ -41,6 +41,14 @@ import arrow.mtl.Kleisli
 import arrow.mtl.KleisliPartialOf
 import arrow.mtl.StateT
 import arrow.mtl.StateTPartialOf
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.extensions.io.functor.functor
+import arrow.fx.extensions.io.monad.monad
+import arrow.fx.mtl.concurrent
+import arrow.fx.mtl.timer
+import arrow.fx.test.generators.genK
+import arrow.fx.test.laws.ConcurrentLaws
 import arrow.mtl.WriterT
 import arrow.mtl.extensions.WriterTEqK
 import arrow.mtl.extensions.kleisli.monadReader.monadReader
@@ -96,15 +104,15 @@ class WriterTTest : UnitSpec() {
         WriterT.genK(Const.genK(Gen.int()), Gen.list(Gen.int()).map { it.k() }),
         constEQK()
       ),
-      // ConcurrentLaws.laws(
-      //   WriterT.concurrent(IO.concurrent(), ListK.monoid<Int>()),
-      //   WriterT.timer(IO.concurrent(), ListK.monoid<Int>()),
-      //   WriterT.functor<ListK<Int>, ForIO>(IO.functor()),
-      //   WriterT.applicative(IO.applicative(), ListK.monoid<Int>()),
-      //   WriterT.monad(IO.monad(), ListK.monoid<Int>()),
-      //   WriterT.genK(IO.genK(), Gen.list(Gen.int()).map { it.k() }),
-      //   ioEQK()
-      // ),
+      ConcurrentLaws.laws(
+        WriterT.concurrent(IO.concurrent(), ListK.monoid<Int>()),
+        WriterT.timer(IO.concurrent(), ListK.monoid<Int>()),
+        WriterT.functor<ListK<Int>, ForIO>(IO.functor()),
+        WriterT.applicative(IO.applicative(), ListK.monoid<Int>()),
+        WriterT.monad(IO.monad(), ListK.monoid<Int>()),
+        WriterT.genK(IO.genK(), Gen.list(Gen.int()).map { it.k() }),
+        ioEQK()
+      ),
       MonoidKLaws.laws(
         WriterT.monoidK<ListK<Int>, ForListK>(ListK.monoidK()),
         WriterT.genK(ListK.genK(), Gen.list(Gen.int()).map { it.k() }),


### PR DESCRIPTION
* The cancellable version being implemented by the instances was the deprecated one, causing the tests to fail
* Also, as @nomisRev found out, it seems that in the Concurrent instances `cancellable` wasn't executing the `CancelToken` properly so it's executed after the `map` composition inside instead of before, possibly causing an issue.


Reverts arrow-kt/arrow-incubator#74
Fixes #75