### PR TITLE
Remove Functor#unit usage

### DIFF
--- a/arrow-docs/src/main/kotlin/RecursionHelper.kt
+++ b/arrow-docs/src/main/kotlin/RecursionHelper.kt
@@ -60,7 +60,7 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForIntListPattern, A>, Ki
   "EXTENSION_SHADOWED_BY_MEMBER"
 )
 fun <A> Kind<ForIntListPattern, A>.void(): IntListPattern<Unit> = IntListPattern.functor().run {
-  unit<A>() as IntListPattern<kotlin.Unit>
+  void<A>() as IntListPattern<kotlin.Unit>
 }
 
 @JvmName("fproduct")

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/eithert.kt
@@ -66,7 +66,7 @@ interface EitherTBracket<L, F> : Bracket<EitherTPartialOf<L, F>, Throwable>, Eit
                 just(Unit)
               })
             }
-            else -> release(either.b, exitCase).value().unit()
+            else -> release(either.b, exitCase).value().void()
           }
           is Either.Left -> just(Unit)
         }
@@ -105,7 +105,7 @@ interface EitherTAsync<L, F> : Async<EitherTPartialOf<L, F>>, EitherTMonadDefer<
   }
 
   override fun <A> asyncF(k: ProcF<EitherTPartialOf<L, F>, A>): EitherT<L, F, A> = ASF().run {
-    EitherT.liftF(this, asyncF { cb -> k(cb).value().unit() })
+    EitherT.liftF(this, asyncF { cb -> k(cb).value().void() })
   }
 
   override fun <A> EitherTOf<L, F, A>.continueOn(ctx: CoroutineContext): EitherT<L, F, A> = ASF().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/optiont.kt
@@ -60,7 +60,7 @@ interface OptionTBracket<F> : Bracket<OptionTPartialOf<F>, Throwable>, OptionTMo
               is ExitCase.Completed -> release(a, exitCase).value().flatMap {
                 it.fold({ ref.set(true) }, { just(Unit) })
               }
-              else -> release(a, exitCase).value().unit()
+              else -> release(a, exitCase).value().void()
             }
           }
         )
@@ -97,7 +97,7 @@ interface OptionTAsync<F> : Async<OptionTPartialOf<F>>, OptionTMonadDefer<F> {
   }
 
   override fun <A> asyncF(k: ProcF<OptionTPartialOf<F>, A>): OptionT<F, A> = AS().run {
-    OptionT.liftF(this, asyncF { cb -> k(cb).value().unit() })
+    OptionT.liftF(this, asyncF { cb -> k(cb).value().void() })
   }
 
   override fun <A> OptionTOf<F, A>.continueOn(ctx: CoroutineContext): OptionT<F, A> = AS().run {

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/statet.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/statet.kt
@@ -56,7 +56,7 @@ interface StateTBracket<S, F> : Bracket<StateTPartialOf<S, F>, Throwable>, State
                   ref.set(Some(s2))
                 }
               }
-            else -> release(a, exitCase).run(s0).unit()
+            else -> release(a, exitCase).run(s0).void()
           }
         }).flatMap { (s, b) -> ref.get().map { it.getOrElse { s } }.tupleRight(b) }
       }

--- a/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
+++ b/arrow-fx-mtl/src/main/kotlin/arrow/fx/mtl/writert.kt
@@ -55,7 +55,7 @@ interface WriterTBracket<W, F> : Bracket<WriterTPartialOf<W, F>, Throwable>, Wri
           val r = release(wa.b, exitCase).value()
           when (exitCase) {
             is ExitCase.Completed -> r.flatMap { (l, _) -> ref.set(l) }
-            else -> r.unit()
+            else -> r.void()
           }
         }).flatMap { (w, b) ->
           ref.get().map { ww -> Tuple2(w.combine(ww), b) }
@@ -92,7 +92,7 @@ interface WriterTAsync<W, F> : Async<WriterTPartialOf<W, F>>, WriterTMonadDefer<
   }
 
   override fun <A> asyncF(k: ProcF<WriterTPartialOf<W, F>, A>): WriterTOf<W, F, A> = AS().run {
-    WriterT.liftF(asyncF { cb -> k(cb).value().unit() }, MM(), this)
+    WriterT.liftF(asyncF { cb -> k(cb).value().void() }, MM(), this)
   }
 
   override fun <A> WriterTOf<W, F, A>.continueOn(ctx: CoroutineContext): WriterT<W, F, A> = AS().run {


### PR DESCRIPTION
https://github.com/arrow-kt/arrow-core/pull/267 removes Functor#unit which has been deprecated since `0.10.x`