### PR TITLE
Deprecate @higherkind & @extension for Either

### DIFF
--- a/arrow-reflect/src/test/kotlin/arrow/reflect/tests/ExtensionsTests.kt
+++ b/arrow-reflect/src/test/kotlin/arrow/reflect/tests/ExtensionsTests.kt
@@ -56,14 +56,6 @@ class ReflectionTests : UnitSpec() {
       TypeClass(Bogus::class).supportedDataTypes().isEmpty() shouldBe true
     }
 
-    "A known instance is found in the data type extensions list" {
-      DataType(Either::class).extensions().contains(TypeClassExtension(
-        DataType(Either::class),
-        TypeClass(MonadError::class),
-        Extension(EitherMonadError::class)
-      )) shouldBe true
-    }
-
     "We can determine a known type class hierarchy" {
       TypeClass(Functor::class).hierarchy() shouldBe listOf(
         TypeClass(Functor::class).extends(TypeClass(Invariant::class))

--- a/arrow-reflect/src/test/kotlin/arrow/reflect/tests/ExtensionsTests.kt
+++ b/arrow-reflect/src/test/kotlin/arrow/reflect/tests/ExtensionsTests.kt
@@ -1,12 +1,8 @@
 package arrow.reflect.tests
 
-import arrow.core.Either
 import arrow.core.Option
-import arrow.core.extensions.EitherMonadError
 import arrow.reflect.DataType
-import arrow.reflect.Extension
 import arrow.reflect.TypeClass
-import arrow.reflect.TypeClassExtension
 import arrow.reflect.extends
 import arrow.reflect.extensions
 import arrow.reflect.hierarchy
@@ -15,7 +11,6 @@ import arrow.reflect.supportedTypeClasses
 import arrow.core.test.UnitSpec
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Invariant
-import arrow.typeclasses.MonadError
 import io.kotlintest.shouldBe
 
 object Bogus


### PR DESCRIPTION
Removes test that tests extensions on `Either`. https://github.com/arrow-kt/arrow-core/pull/272

`@extensions` will be removed from Arrow Reflect